### PR TITLE
Update CHANGELOG with all changes since 0.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,38 @@
 ## [Unreleased]
 
-- Improvements to CI/CD
-  - Enable CodeQL
-  - Enable Dependabot
-  - Enable Rubocop Testing
-  - Enable unit testing against Ruby v3.2, v3.3, v3.4
+### Added
+
+- POST item endpoint (`post_item`) with test helpers for error scenarios
+  (invalid item, access denied, data policy violation, request limit)
+- Search items (`search_items`, `suggest_items`) and search properties
+  (`search_properties`) endpoints
+- Language fallback handling for labels via 307 redirect following
+- Integration test suite with Docker Compose (Wikibase stack), helper
+  scripts (`integration-up`, `integration-test`, `integration-down`),
+  and RSpec filter to exclude integration tests by default
+- Test helpers using OpenAPI spec v1.4 examples for response fixtures
+- Bundled copy of OpenAPI Spec v1.4 for test comparisons
+- `CLAUDE.md` project guidance
+- `rubocop-rake` and `rubocop-rspec` plugins
+
+### Changed
+
+- Refactored `RestApi` into separate modules per resource: Items, Labels,
+  Descriptions, Aliases, Statements, Sitelinks, Properties, PropertyDataTypes,
+  OpenApiDocument, SearchItem, SearchProperty
+- Moved spec paths to mirror source layout
+  (`spec/wikidata_adaptor/rest_api/`)
+- Updated API paths to target v1 endpoints
+- Updated `api_adaptor` dependency to v0.1.0
+- Updated `stub_rest_api_request` to accept headers
+- Updated target Ruby version to >= 3.2
+
+### Fixed
+
+- RuboCop offenses: `RSpec/BeNil`, `RSpec/EmptyLineAfterExample`,
+  `RSpec/SpecFilePathFormat` (missing `_spec` suffix on
+  `property_data_types`)
 
 ## [0.0.0] - 2023-06-01
 
-- Initial Bootstrapping
+- Initial bootstrapping


### PR DESCRIPTION
## Summary

- Replace the sparse CI/CD-only changelog entries with a complete record of all significant changes since `[0.0.0]`
- Organise using [Keep a Changelog](https://keepachangelog.com/) categories: Added, Changed, Fixed
- Cover new endpoints, integration test suite, modular refactoring, dependency updates, and RuboCop fixes

## Test plan

- [ ] Review changelog entries against git history for accuracy and completeness
- [ ] Confirm Keep a Changelog formatting conventions are followed

🤖 Generated with [Claude Code](https://claude.com/claude-code)