### PR TITLE
Add description language fallback endpoints

### DIFF
--- a/lib/wikidata_adaptor/rest_api/descriptions.rb
+++ b/lib/wikidata_adaptor/rest_api/descriptions.rb
@@ -23,6 +23,20 @@ module WikidataAdaptor
         get_json("#{endpoint}/v1/entities/items/#{CGI.escape(item_id)}/descriptions/#{lang_code}")
       end
 
+      # Retrieve an Item's description in a specific language, using Wikibase language fallback.
+      #
+      # NOTE: The OpenAPI spec documents that this endpoint may respond with a redirect
+      # (e.g. 307/308) and a Location header. api_adaptor v0.1.0+ follows these
+      # redirects.
+      #
+      # @param [String] item_id The ID of the required Item.
+      # @param [String] lang_code The requested resource language.
+      #
+      # @return [String] Item's description in a specific language.
+      def get_item_description_with_language_fallback(item_id, lang_code)
+        get_json("#{endpoint}/v1/entities/items/#{CGI.escape(item_id)}/descriptions_with_language_fallback/#{lang_code}")
+      end
+
       # Retrieve a Property's descriptions.
       #
       # @param [String] property_id The ID of the required Property.
@@ -40,6 +54,20 @@ module WikidataAdaptor
       # @return [String] Property's description in a specific language.
       def get_property_description(property_id, lang_code)
         get_json("#{endpoint}/v1/entities/properties/#{CGI.escape(property_id)}/descriptions/#{lang_code}")
+      end
+
+      # Retrieve a Property's description in a specific language, using Wikibase language fallback.
+      #
+      # NOTE: The OpenAPI spec documents that this endpoint may respond with a redirect
+      # (e.g. 307/308) and a Location header. api_adaptor v0.1.0+ follows these
+      # redirects.
+      #
+      # @param [String] property_id The ID of the required Property.
+      # @param [String] lang_code The requested resource language.
+      #
+      # @return [String] Property's description in a specific language.
+      def get_property_description_with_language_fallback(property_id, lang_code)
+        get_json("#{endpoint}/v1/entities/properties/#{CGI.escape(property_id)}/descriptions_with_language_fallback/#{lang_code}")
       end
     end
   end

--- a/lib/wikidata_adaptor/test_helpers/rest_api/descriptions.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/descriptions.rb
@@ -29,6 +29,41 @@ module WikidataAdaptor
           )
         end
 
+        ###############################################################################
+        # GET /v1/entities/items/:item_id/descriptions_with_language_fallback/:language_code
+        ###############################################################################
+        def stub_get_item_description_with_language_fallback(item_id, language_code)
+          stub_rest_api_request(
+            :get,
+            "/v1/entities/items/#{item_id}/descriptions_with_language_fallback/#{language_code}",
+            response_body: "English science fiction writer and humourist"
+          )
+        end
+
+        ###############################################################################
+        # GET /v1/entities/items/:item_id/descriptions_with_language_fallback/:language_code
+        # -> 307 Location: /v1/entities/items/:item_id/descriptions/:redirect_language_code
+        ###############################################################################
+        def stub_get_item_description_with_language_fallback_redirect(item_id, language_code,
+                                                                      redirect_language_code: language_code,
+                                                                      response_body: "English science fiction writer and humourist")
+          stub_rest_api_request(
+            :get,
+            "/v1/entities/items/#{item_id}/descriptions_with_language_fallback/#{language_code}",
+            response_status: 307,
+            response_headers: {
+              "Location" => "#{WIKIBASE_REST_ENDPOINT}/v1/entities/items/#{item_id}/descriptions/#{redirect_language_code}"
+            },
+            response_body: ""
+          )
+
+          stub_rest_api_request(
+            :get,
+            "/v1/entities/items/#{item_id}/descriptions/#{redirect_language_code}",
+            response_body: response_body
+          )
+        end
+
         ##############################################
         # GET /v1/entities/properties/:property_id/descriptions
         ##############################################
@@ -51,6 +86,41 @@ module WikidataAdaptor
             :get,
             "/v1/entities/properties/#{property_id}/descriptions/#{language_code}",
             response_body: "that class of which this subject is a particular example and member"
+          )
+        end
+
+        #######################################################################################
+        # GET /v1/entities/properties/:property_id/descriptions_with_language_fallback/:language_code
+        #######################################################################################
+        def stub_get_property_description_with_language_fallback(property_id, language_code)
+          stub_rest_api_request(
+            :get,
+            "/v1/entities/properties/#{property_id}/descriptions_with_language_fallback/#{language_code}",
+            response_body: "that class of which this subject is a particular example and member"
+          )
+        end
+
+        #######################################################################################
+        # GET /v1/entities/properties/:property_id/descriptions_with_language_fallback/:language_code
+        # -> 307 Location: /v1/entities/properties/:property_id/descriptions/:redirect_language_code
+        #######################################################################################
+        def stub_get_property_description_with_language_fallback_redirect(property_id, language_code,
+                                                                          redirect_language_code: language_code,
+                                                                          response_body: "that class of which this subject is a particular example and member")
+          stub_rest_api_request(
+            :get,
+            "/v1/entities/properties/#{property_id}/descriptions_with_language_fallback/#{language_code}",
+            response_status: 307,
+            response_headers: {
+              "Location" => "#{WIKIBASE_REST_ENDPOINT}/v1/entities/properties/#{property_id}/descriptions/#{redirect_language_code}"
+            },
+            response_body: ""
+          )
+
+          stub_rest_api_request(
+            :get,
+            "/v1/entities/properties/#{property_id}/descriptions/#{redirect_language_code}",
+            response_body: response_body
           )
         end
       end

--- a/spec/wikidata_adaptor/rest_api/descriptions_spec.rb
+++ b/spec/wikidata_adaptor/rest_api/descriptions_spec.rb
@@ -33,6 +33,24 @@ RSpec.describe WikidataAdaptor::RestApi::Descriptions do
     end
   end
 
+  describe "#get_item_description_with_language_fallback" do
+    context "when the description is defined in the requested language" do
+      it "returns 200 with the description" do
+        stub_get_item_description_with_language_fallback(item_id, "en")
+        expect(api_client.get_item_description_with_language_fallback(item_id, "en").raw_response_body)
+          .to eq("English science fiction writer and humourist")
+      end
+    end
+
+    context "when the description exists only in a fallback language" do
+      it "follows the 307 Location redirect" do
+        stub_get_item_description_with_language_fallback_redirect(item_id, "en")
+        expect(api_client.get_item_description_with_language_fallback(item_id, "en").raw_response_body)
+          .to eq("English science fiction writer and humourist")
+      end
+    end
+  end
+
   describe "#get_property_descriptions" do
     it "gets property descriptions in all locales by property_id" do
       stub_get_property_descriptions(property_id)
@@ -51,6 +69,24 @@ RSpec.describe WikidataAdaptor::RestApi::Descriptions do
         .to eq(
           "that class of which this subject is a particular example and member"
         )
+    end
+  end
+
+  describe "#get_property_description_with_language_fallback" do
+    context "when the description is defined in the requested language" do
+      it "returns 200 with the description" do
+        stub_get_property_description_with_language_fallback(property_id, "en")
+        expect(api_client.get_property_description_with_language_fallback(property_id, "en").raw_response_body)
+          .to eq("that class of which this subject is a particular example and member")
+      end
+    end
+
+    context "when the description exists only in a fallback language" do
+      it "follows the 307 Location redirect" do
+        stub_get_property_description_with_language_fallback_redirect(property_id, "en")
+        expect(api_client.get_property_description_with_language_fallback(property_id, "en").raw_response_body)
+          .to eq("that class of which this subject is a particular example and member")
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

- Add `get_item_description_with_language_fallback` and `get_property_description_with_language_fallback` to the Descriptions module
- Add corresponding test helper stubs including 307 redirect variants
- Add unit tests for direct and redirect responses

Mirrors the existing language fallback pattern already in place for Labels. This completes Phase 1 of the [API coverage TODO](../blob/main/TODO.md) — all GET endpoints in the OpenAPI v1.4 spec are now covered (32/65, up from 30/65).

## Test plan

- [x] `bundle exec rake` passes (55 examples, 0 failures, no RuboCop offenses)
- [ ] Review against OpenAPI spec for correctness of path patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)