### PR TITLE
Add POST endpoints for aliases, statements, and properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - POST item endpoint (`post_item`) with test helpers for error scenarios
   (invalid item, access denied, data policy violation, request limit)
+- POST property endpoint (`post_property`) with matching error stubs
+- POST aliases endpoints (`post_item_aliases`, `post_property_aliases`)
+  to append aliases in a given language
+- POST statement endpoints (`post_item_statement`,
+  `post_property_statement`) to create statements on entities
 - Search items (`search_items`, `suggest_items`) and search properties
   (`search_properties`) endpoints
 - Language fallback handling for labels via 307 redirect following

--- a/lib/wikidata_adaptor/rest_api/aliases.rb
+++ b/lib/wikidata_adaptor/rest_api/aliases.rb
@@ -23,6 +23,17 @@ module WikidataAdaptor
         get_json("#{endpoint}/v1/entities/items/#{CGI.escape(item_id)}/aliases/#{lang_code}")
       end
 
+      # Add aliases to an Item in a specific language.
+      #
+      # @param [String] item_id The ID of the Item.
+      # @param [String] lang_code The language code.
+      # @param [Hash] payload Aliases and edit metadata.
+      #
+      # @return [Array<String>] The updated list of aliases.
+      def post_item_aliases(item_id, lang_code, payload)
+        post_json("#{endpoint}/v1/entities/items/#{CGI.escape(item_id)}/aliases/#{lang_code}", payload)
+      end
+
       # Retrieve a Property's aliases.
       #
       # @param [String] property_id The ID of the required Property.
@@ -40,6 +51,17 @@ module WikidataAdaptor
       # @return [Array[String]] Property's aliases in a specific language.
       def get_property_alias(property_id, lang_code)
         get_json("#{endpoint}/v1/entities/properties/#{CGI.escape(property_id)}/aliases/#{lang_code}")
+      end
+
+      # Add aliases to a Property in a specific language.
+      #
+      # @param [String] property_id The ID of the Property.
+      # @param [String] lang_code The language code.
+      # @param [Hash] payload Aliases and edit metadata.
+      #
+      # @return [Array<String>] The updated list of aliases.
+      def post_property_aliases(property_id, lang_code, payload)
+        post_json("#{endpoint}/v1/entities/properties/#{CGI.escape(property_id)}/aliases/#{lang_code}", payload)
       end
     end
   end

--- a/lib/wikidata_adaptor/rest_api/properties.rb
+++ b/lib/wikidata_adaptor/rest_api/properties.rb
@@ -12,6 +12,15 @@ module WikidataAdaptor
       def get_property(property_id)
         get_json("#{endpoint}/v1/entities/properties/#{CGI.escape(property_id)}")
       end
+
+      # Create a Wikibase Property.
+      #
+      # @param [Hash] payload Property containing a Wikibase Property and edit metadata.
+      #
+      # @return [Hash] A single Wikibase Property.
+      def post_property(payload)
+        post_json("#{endpoint}/v1/entities/properties", payload)
+      end
     end
   end
 end

--- a/lib/wikidata_adaptor/rest_api/statements.rb
+++ b/lib/wikidata_adaptor/rest_api/statements.rb
@@ -18,6 +18,16 @@ module WikidataAdaptor
         get_json("#{endpoint}/v1/entities/items/#{CGI.escape(item_id)}/statements/#{statement_id}")
       end
 
+      # Add a Statement to an Item.
+      #
+      # @param [String] item_id The ID of the Item.
+      # @param [Hash] payload Statement and edit metadata.
+      #
+      # @return [Hash] The newly created Statement.
+      def post_item_statement(item_id, payload)
+        post_json("#{endpoint}/v1/entities/items/#{CGI.escape(item_id)}/statements", payload)
+      end
+
       # Retrieve a single Statement (global).
       def get_statement(statement_id)
         get_json("#{endpoint}/v1/statements/#{statement_id}")
@@ -31,6 +41,16 @@ module WikidataAdaptor
       # Retrieve a single Statement from a Property.
       def get_property_statement(property_id, statement_id)
         get_json("#{endpoint}/v1/entities/properties/#{CGI.escape(property_id)}/statements/#{statement_id}")
+      end
+
+      # Add a Statement to a Property.
+      #
+      # @param [String] property_id The ID of the Property.
+      # @param [Hash] payload Statement and edit metadata.
+      #
+      # @return [Hash] The newly created Statement.
+      def post_property_statement(property_id, payload)
+        post_json("#{endpoint}/v1/entities/properties/#{CGI.escape(property_id)}/statements", payload)
       end
     end
   end

--- a/lib/wikidata_adaptor/test_helpers/rest_api/aliases.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/aliases.rb
@@ -37,6 +37,42 @@ module WikidataAdaptor
           )
         end
 
+        ############################################################
+        # POST /v1/entities/items/:item_id/aliases/:language_code
+        ############################################################
+        def stub_post_item_aliases(item_id, language_code, payload, response_body: nil)
+          stub_rest_api_request(
+            :post,
+            "/v1/entities/items/#{item_id}/aliases/#{language_code}",
+            response_status: 200,
+            with: { body: payload.to_json },
+            response_body: response_body || ["Douglas Noel Adams", "Douglas Noël Adams"]
+          )
+        end
+
+        def stub_post_item_aliases_created(item_id, language_code, payload, response_body: nil)
+          stub_rest_api_request(
+            :post,
+            "/v1/entities/items/#{item_id}/aliases/#{language_code}",
+            response_status: 201,
+            with: { body: payload.to_json },
+            response_body: response_body || ["Douglas Noel Adams", "Douglas Noël Adams"]
+          )
+        end
+
+        def stub_post_item_aliases_unexpected_error(item_id, language_code, payload)
+          stub_rest_api_request(
+            :post,
+            "/v1/entities/items/#{item_id}/aliases/#{language_code}",
+            response_status: 500,
+            with: { body: payload.to_json },
+            response_body: {
+              code: "unexpected-error",
+              message: "Unexpected Error"
+            }
+          )
+        end
+
         ########################################
         # GET /v1/entities/properties/:property_id/aliases
         ########################################
@@ -59,6 +95,42 @@ module WikidataAdaptor
             :get,
             "/v1/entities/properties/#{property_id}/aliases/#{language_code}",
             response_body: ["is a"]
+          )
+        end
+
+        ################################################################
+        # POST /v1/entities/properties/:property_id/aliases/:language_code
+        ################################################################
+        def stub_post_property_aliases(property_id, language_code, payload, response_body: nil)
+          stub_rest_api_request(
+            :post,
+            "/v1/entities/properties/#{property_id}/aliases/#{language_code}",
+            response_status: 200,
+            with: { body: payload.to_json },
+            response_body: response_body || ["is a", "is an"]
+          )
+        end
+
+        def stub_post_property_aliases_created(property_id, language_code, payload, response_body: nil)
+          stub_rest_api_request(
+            :post,
+            "/v1/entities/properties/#{property_id}/aliases/#{language_code}",
+            response_status: 201,
+            with: { body: payload.to_json },
+            response_body: response_body || ["is a", "is an"]
+          )
+        end
+
+        def stub_post_property_aliases_unexpected_error(property_id, language_code, payload)
+          stub_rest_api_request(
+            :post,
+            "/v1/entities/properties/#{property_id}/aliases/#{language_code}",
+            response_status: 500,
+            with: { body: payload.to_json },
+            response_body: {
+              code: "unexpected-error",
+              message: "Unexpected Error"
+            }
           )
         end
       end

--- a/lib/wikidata_adaptor/test_helpers/rest_api/properties.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/properties.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
+require_relative "support/support"
 module WikidataAdaptor
   module TestHelpers
     module RestApi
       module Properties
+        include WikidataAdaptor::TestHelpers::RestApi::Support
+
         ###############################
         # GET /v1/entities/properties/:property_id
         ###############################
@@ -60,6 +63,93 @@ module WikidataAdaptor
             :get,
             "/v1/entities/properties/#{property_id}",
             response_status: 500,
+            response_body: {
+              code: "unexpected-error",
+              message: "Unexpected Error"
+            }
+          )
+        end
+
+        ###############################
+        # POST /v1/entities/properties
+        ###############################
+        def stub_post_property(payload, response_body = nil)
+          stub_rest_api_request(
+            :post,
+            "/v1/entities/properties",
+            response_status: 201,
+            with: { body: payload.to_json },
+            response_body: response_body || posted_property_response_fixture.to_json
+          )
+        end
+
+        def stub_post_property_invalid_property(response_body = nil)
+          stub_rest_api_request(
+            :post,
+            "/v1/entities/properties",
+            response_status: 400,
+            response_body: response_body || {
+              code: "invalid-property-data",
+              message: "The provided property data is invalid."
+            }
+          )
+        end
+
+        def stub_post_property_access_denied
+          stub_rest_api_request(
+            :post,
+            "/v1/entities/properties",
+            response_status: 403,
+            response_body: {
+              code: "permission-denied",
+              message: "Access to resource is denied",
+              context: {
+                denial_reason: "{reason_code}",
+                denial_context: "{additional_context}"
+              }
+            }
+          )
+        end
+
+        def stub_post_property_data_policy_violation
+          stub_rest_api_request(
+            :post,
+            "/v1/entities/properties",
+            response_status: 422,
+            response_body: {
+              code: "data-policy-violation",
+              message: "Edit violates data policy",
+              context: {
+                violation: "{violation_code}",
+                violation_context: {
+                  some: "context"
+                }
+              }
+            }
+          )
+        end
+
+        def stub_post_property_request_limit_reached
+          stub_rest_api_request(
+            :post,
+            "/v1/entities/properties",
+            response_status: 429,
+            response_body: {
+              code: "request-limit-reached",
+              message: "Exceeded the limit of actions that can be performed in a given span of time",
+              context: {
+                reason: "{reason_code}"
+              }
+            }
+          )
+        end
+
+        def stub_post_property_unexpected_error(payload)
+          stub_rest_api_request(
+            :post,
+            "/v1/entities/properties",
+            response_status: 500,
+            with: { body: payload.to_json },
             response_body: {
               code: "unexpected-error",
               message: "Unexpected Error"

--- a/lib/wikidata_adaptor/test_helpers/rest_api/statements.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/statements.rb
@@ -44,6 +44,39 @@ module WikidataAdaptor
           )
         end
 
+        ##########################################
+        # POST /v1/entities/items/:item_id/statements
+        ##########################################
+        def stub_post_item_statement(item_id, payload, response_body: nil)
+          stub_rest_api_request(
+            :post,
+            "/v1/entities/items/#{item_id}/statements",
+            response_status: 201,
+            with: { body: payload.to_json },
+            response_body: response_body || {
+              id: "Q42$6403c562-401a-2b26-85cc-8327801145e1",
+              rank: "normal",
+              property: { id: "P92", "data-type": "string" },
+              value: { content: "I am a goat", type: "value" },
+              qualifiers: [],
+              references: []
+            }
+          )
+        end
+
+        def stub_post_item_statement_unexpected_error(item_id, payload)
+          stub_rest_api_request(
+            :post,
+            "/v1/entities/items/#{item_id}/statements",
+            response_status: 500,
+            with: { body: payload.to_json },
+            response_body: {
+              code: "unexpected-error",
+              message: "Unexpected Error"
+            }
+          )
+        end
+
         ###############################
         # GET /v1/statements/:statement_id
         ###############################
@@ -87,6 +120,39 @@ module WikidataAdaptor
               value: { content: "Q5", type: "value" },
               qualifiers: [],
               references: []
+            }
+          )
+        end
+
+        ##################################################
+        # POST /v1/entities/properties/:property_id/statements
+        ##################################################
+        def stub_post_property_statement(property_id, payload, response_body: nil)
+          stub_rest_api_request(
+            :post,
+            "/v1/entities/properties/#{property_id}/statements",
+            response_status: 201,
+            with: { body: payload.to_json },
+            response_body: response_body || {
+              id: "P31$11111111-2222-3333-4444-555555555555",
+              rank: "normal",
+              property: { id: property_id.to_s, "data-type": "wikibase-item" },
+              value: { content: "Q5", type: "value" },
+              qualifiers: [],
+              references: []
+            }
+          )
+        end
+
+        def stub_post_property_statement_unexpected_error(property_id, payload)
+          stub_rest_api_request(
+            :post,
+            "/v1/entities/properties/#{property_id}/statements",
+            response_status: 500,
+            with: { body: payload.to_json },
+            response_body: {
+              code: "unexpected-error",
+              message: "Unexpected Error"
             }
           )
         end

--- a/lib/wikidata_adaptor/test_helpers/rest_api/support/support.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/support/support.rb
@@ -144,6 +144,42 @@ module WikidataAdaptor
           }
         end
 
+        def posted_property_response_fixture
+          {
+            "id" => "P1",
+            "type" => "property",
+            "data_type" => "string",
+            "labels" => {
+              "en" => "instance of"
+            },
+            "descriptions" => {
+              "en" => "that class of which this subject is a particular example and member"
+            },
+            "aliases" => {
+              "en" => ["is a"]
+            },
+            "statements" => {}
+          }
+        end
+
+        def posted_property_payload_fixture
+          {
+            "property" => {
+              "data_type" => "string",
+              "labels" => {
+                "en" => "instance of"
+              },
+              "descriptions" => {
+                "en" => "that class of which this subject is a particular example and member"
+              },
+              "aliases" => {
+                "en" => ["is a"]
+              }
+            },
+            "comment" => "Create a Property"
+          }
+        end
+
         def posted_item_payload_fixture
           {
             "item" => {

--- a/spec/integration/aliases_spec.rb
+++ b/spec/integration/aliases_spec.rb
@@ -36,6 +36,16 @@ RSpec.describe "Aliases", :integration do
         expect(result).to eq([@alias_a, @alias_b])
       end
     end
+
+    describe "#post_item_aliases" do
+      it "adds aliases and returns the updated list" do
+        new_alias = "New alias #{SecureRandom.hex(4)}"
+        payload = { "aliases" => [new_alias], "comment" => "integration test" }
+        result = api_client.post_item_aliases(@item["id"], "en", payload).parsed_content
+
+        expect(result).to include(new_alias)
+      end
+    end
   end
 
   describe "property aliases" do
@@ -66,6 +76,16 @@ RSpec.describe "Aliases", :integration do
         result = api_client.get_property_alias(@property["id"], "en").parsed_content
 
         expect(result).to eq([@prop_alias_en])
+      end
+    end
+
+    describe "#post_property_aliases" do
+      it "adds aliases and returns the updated list" do
+        new_alias = "Prop new alias #{SecureRandom.hex(4)}"
+        payload = { "aliases" => [new_alias], "comment" => "integration test" }
+        result = api_client.post_property_aliases(@property["id"], "en", payload).parsed_content
+
+        expect(result).to include(new_alias)
       end
     end
   end

--- a/spec/integration/properties_spec.rb
+++ b/spec/integration/properties_spec.rb
@@ -33,4 +33,26 @@ RSpec.describe "Properties", :integration do
       expect { api_client.get_property("P99999999") }.to raise_error(ApiAdaptor::HTTPNotFound)
     end
   end
+
+  describe "#post_property" do
+    it "creates a new property and returns it" do
+      label = "Post prop #{SecureRandom.hex(4)}"
+      desc = "Created by integration #{SecureRandom.hex(4)}"
+      payload = {
+        "property" => {
+          "data_type" => "string",
+          "labels" => { "en" => label },
+          "descriptions" => { "en" => desc }
+        },
+        "comment" => "integration test"
+      }
+      result = api_client.post_property(payload).parsed_content
+
+      expect(result["id"]).to match(/\AP\d+\z/)
+      expect(result["type"]).to eq("property")
+      expect(result["data_type"]).to eq("string")
+      expect(result["labels"]).to include("en" => label)
+      expect(result["descriptions"]).to include("en" => desc)
+    end
+  end
 end

--- a/spec/integration/statements_spec.rb
+++ b/spec/integration/statements_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe "Statements", :integration do
       extend WikidataAdaptor::Integration::Helpers
 
       @item = create_item!(labels: { "en" => "Stmts item #{SecureRandom.hex(4)}" })
+      @string_property = create_property!(
+        data_type: "string",
+        labels: { "en" => "Stmts string prop #{SecureRandom.hex(4)}" }
+      )
     end
 
     describe "#get_item_statements" do
@@ -20,6 +24,24 @@ RSpec.describe "Statements", :integration do
         expect(result).to be_empty
       end
     end
+
+    describe "#post_item_statement" do
+      it "creates a statement on an item and returns it" do
+        payload = {
+          "statement" => {
+            "property" => { "id" => @string_property["id"] },
+            "value" => { "type" => "value", "content" => "test value" }
+          },
+          "comment" => "integration test"
+        }
+        result = api_client.post_item_statement(@item["id"], payload).parsed_content
+
+        expect(result["id"]).to match(/\A#{@item["id"]}\$/)
+        expect(result["rank"]).to eq("normal")
+        expect(result["property"]["id"]).to eq(@string_property["id"])
+        expect(result["value"]["content"]).to eq("test value")
+      end
+    end
   end
 
   describe "property statements" do
@@ -27,6 +49,10 @@ RSpec.describe "Statements", :integration do
       extend WikidataAdaptor::Integration::Helpers
 
       @property = create_property!(labels: { "en" => "Stmts prop #{SecureRandom.hex(4)}" })
+      @string_property = create_property!(
+        data_type: "string",
+        labels: { "en" => "Stmts string prop 2 #{SecureRandom.hex(4)}" }
+      )
     end
 
     describe "#get_property_statements" do
@@ -35,6 +61,24 @@ RSpec.describe "Statements", :integration do
 
         expect(result).to be_a(Hash)
         expect(result).to be_empty
+      end
+    end
+
+    describe "#post_property_statement" do
+      it "creates a statement on a property and returns it" do
+        payload = {
+          "statement" => {
+            "property" => { "id" => @string_property["id"] },
+            "value" => { "type" => "value", "content" => "test value" }
+          },
+          "comment" => "integration test"
+        }
+        result = api_client.post_property_statement(@property["id"], payload).parsed_content
+
+        expect(result["id"]).to match(/\A#{@property["id"]}\$/)
+        expect(result["rank"]).to eq("normal")
+        expect(result["property"]["id"]).to eq(@string_property["id"])
+        expect(result["value"]["content"]).to eq("test value")
       end
     end
   end

--- a/spec/wikidata_adaptor/rest_api/aliases_spec.rb
+++ b/spec/wikidata_adaptor/rest_api/aliases_spec.rb
@@ -39,6 +39,21 @@ RSpec.describe WikidataAdaptor::RestApi::Aliases do
     end
   end
 
+  describe "#post_item_aliases" do
+    let(:payload) { { "aliases" => ["Douglas Noel Adams"], "comment" => "Add alias" } }
+
+    it "adds aliases to an item and returns the updated list" do
+      stub_post_item_aliases(item_id, "en", payload)
+      expect(api_client.post_item_aliases(item_id, "en", payload).parsed_content)
+        .to eq(["Douglas Noel Adams", "Douglas Noël Adams"])
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_post_item_aliases_unexpected_error(item_id, "en", payload)
+      expect { api_client.post_item_aliases(item_id, "en", payload) }.to raise_error(ApiAdaptor::HTTPInternalServerError)
+    end
+  end
+
   describe "#get_property_aliases" do
     it "gets property aliases in all locales by property_id" do
       stub_get_property_aliases(property_id)
@@ -55,6 +70,21 @@ RSpec.describe WikidataAdaptor::RestApi::Aliases do
       stub_get_property_alias(property_id, "en")
       expect(api_client.get_property_alias(property_id, "en").parsed_content)
         .to eq(["is a"])
+    end
+  end
+
+  describe "#post_property_aliases" do
+    let(:payload) { { "aliases" => ["is an"], "comment" => "Add alias" } }
+
+    it "adds aliases to a property and returns the updated list" do
+      stub_post_property_aliases(property_id, "en", payload)
+      expect(api_client.post_property_aliases(property_id, "en", payload).parsed_content)
+        .to eq(["is a", "is an"])
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_post_property_aliases_unexpected_error(property_id, "en", payload)
+      expect { api_client.post_property_aliases(property_id, "en", payload) }.to raise_error(ApiAdaptor::HTTPInternalServerError)
     end
   end
 end

--- a/spec/wikidata_adaptor/rest_api/properties_spec.rb
+++ b/spec/wikidata_adaptor/rest_api/properties_spec.rb
@@ -34,4 +34,38 @@ RSpec.describe WikidataAdaptor::RestApi::Properties do
       expect { api_client.get_property(property_id) }.to raise_error(ApiAdaptor::HTTPInternalServerError)
     end
   end
+
+  describe "#post_property" do
+    it "creates a new property" do
+      stub_post_property(posted_property_payload_fixture)
+      expect(api_client.post_property(posted_property_payload_fixture).parsed_content).to eq(
+        posted_property_response_fixture
+      )
+    end
+
+    it "raises a 400 response status for an invalid request" do
+      stub_post_property_invalid_property
+      expect { api_client.post_property({}) }.to raise_error(ApiAdaptor::HTTPBadRequest)
+    end
+
+    it "raises a 403 response status if access is denied" do
+      stub_post_property_access_denied
+      expect { api_client.post_property({}) }.to raise_error(ApiAdaptor::HTTPForbidden)
+    end
+
+    it "raises a 422 response status if the edit request violates data policy" do
+      stub_post_property_data_policy_violation
+      expect { api_client.post_property({}) }.to raise_error(ApiAdaptor::HTTPUnprocessableEntity)
+    end
+
+    it "raises a 429 response status if the request limit is exceeded" do
+      stub_post_property_request_limit_reached
+      expect { api_client.post_property({}) }.to raise_error(ApiAdaptor::HTTPTooManyRequests)
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_post_property_unexpected_error({})
+      expect { api_client.post_property({}) }.to raise_error(ApiAdaptor::HTTPInternalServerError)
+    end
+  end
 end

--- a/spec/wikidata_adaptor/rest_api/statements_spec.rb
+++ b/spec/wikidata_adaptor/rest_api/statements_spec.rb
@@ -52,6 +52,32 @@ RSpec.describe WikidataAdaptor::RestApi::Statements do
     end
   end
 
+  describe "#post_item_statement" do
+    let(:payload) do
+      {
+        "statement" => {
+          "property" => { "id" => "P92" },
+          "value" => { "type" => "value", "content" => "I am a goat" }
+        },
+        "comment" => "Add statement"
+      }
+    end
+
+    it "creates a new statement on an item" do
+      stub_post_item_statement(item_id, payload)
+      response = api_client.post_item_statement(item_id, payload).parsed_content
+      expect(response).to include(
+        "id" => "Q42$6403c562-401a-2b26-85cc-8327801145e1",
+        "rank" => "normal"
+      )
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_post_item_statement_unexpected_error(item_id, payload)
+      expect { api_client.post_item_statement(item_id, payload) }.to raise_error(ApiAdaptor::HTTPInternalServerError)
+    end
+  end
+
   describe "#get_statement" do
     it "returns a specific statement by statement_id" do
       stub_get_statement(statement_id)
@@ -101,6 +127,32 @@ RSpec.describe WikidataAdaptor::RestApi::Statements do
                  "qualifiers" => [],
                  "references" => []
                })
+    end
+  end
+
+  describe "#post_property_statement" do
+    let(:payload) do
+      {
+        "statement" => {
+          "property" => { "id" => property_id },
+          "value" => { "type" => "value", "content" => "Q5" }
+        },
+        "comment" => "Add statement"
+      }
+    end
+
+    it "creates a new statement on a property" do
+      stub_post_property_statement(property_id, payload)
+      response = api_client.post_property_statement(property_id, payload).parsed_content
+      expect(response).to include(
+        "id" => "P31$11111111-2222-3333-4444-555555555555",
+        "rank" => "normal"
+      )
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_post_property_statement_unexpected_error(property_id, payload)
+      expect { api_client.post_property_statement(property_id, payload) }.to raise_error(ApiAdaptor::HTTPInternalServerError)
     end
   end
 end


### PR DESCRIPTION
## Summary

- Add `post_item_aliases` and `post_property_aliases` to the Aliases module (append aliases in a given language)
- Add `post_item_statement` and `post_property_statement` to the Statements module (create a statement on an entity)
- Add `post_property` to the Properties module (create a new property, with full error stubs mirroring `post_item`)
- Add shared property fixtures (`posted_property_payload_fixture`, `posted_property_response_fixture`) to the Support module

This completes Phase 2 of the [API coverage TODO](../blob/main/TODO.md) — all POST endpoints in the OpenAPI v1.4 spec are now covered (35/65, up from 30/65).

## Test plan

- [x] `bundle exec rake` passes (65 examples, 0 failures, no RuboCop offenses)
- [ ] Review against OpenAPI spec for correctness of path patterns and response shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)