### PR TITLE
Add PUT endpoints for resource replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@
   to append aliases in a given language
 - POST statement endpoints (`post_item_statement`,
   `post_property_statement`) to create statements on entities
+- PUT label endpoints (`put_item_label`, `put_property_label`)
+  to replace a single label by language
+- PUT description endpoints (`put_item_description`,
+  `put_property_description`) to replace a single description by language
+- PUT sitelink endpoint (`put_item_sitelink`) to replace a sitelink
+  by site ID
+- PUT statement endpoints (`put_item_statement`,
+  `put_property_statement`, `put_statement`) to replace statements
 - Search items (`search_items`, `suggest_items`) and search properties
   (`search_properties`) endpoints
 - Language fallback handling for labels via 307 redirect following

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,15 @@ Follows [GDS Git conventions](https://gds-way.digital.cabinet-office.gov.uk/stan
 - **Tell a story** — commits should be logically ordered so the history reads as a coherent narrative, not a jumbled log
 - **Clean up before sharing** — revise commit history on feature branches before opening a PR
 
+## Development Workflow (TDD)
+
+When adding new API endpoints, follow this test-driven approach:
+
+1. **Write unit tests (red)** — Add `describe` blocks to the relevant spec file calling `stub_*` and API methods that don't exist yet. Verify `bundle exec rubocop` passes and `bundle exec rspec` fails.
+2. **Add test helpers + implementation (green)** — Add `stub_*` helpers and implement the API methods. Verify `bundle exec rake` passes (rspec + rubocop).
+3. **Add integration tests** — Add tests to `spec/integration/` that exercise the real API.
+4. **Update TODO** — Move endpoints from "Uncovered" to "Covered" in `TODO.md` and update counts.
+
 ## Style
 
 - Double quotes for strings

--- a/TODO.md
+++ b/TODO.md
@@ -2,11 +2,11 @@
 
 Tracking coverage of Wikibase REST API v1.4 (OpenAPI spec).
 
-**Covered: 30 / 65 endpoints (46%)**
+**Covered: 45 / 65 endpoints (69%)**
 
 ## Covered endpoints
 
-All GET endpoints plus `POST /v1/entities/items` are implemented.
+All GET, POST, and PUT endpoints are implemented.
 
 | # | Method | Path | Ruby method | Module |
 |---|--------|------|-------------|--------|
@@ -40,25 +40,23 @@ All GET endpoints plus `POST /v1/entities/items` are implemented.
 | 28 | GET | `/v1/property-data-types` | `get_property_data_types` | PropertyDataTypes |
 | 29 | GET | `/v1/statements/{statement_id}` | `get_statement` | Statements |
 | 30 | POST | `/v1/entities/items` | `post_item` | Items |
+| 31 | GET | `/v1/entities/items/{item_id}/descriptions_with_language_fallback/{language_code}` | `get_item_description_with_language_fallback` | Descriptions |
+| 32 | GET | `/v1/entities/properties/{property_id}/descriptions_with_language_fallback/{language_code}` | `get_property_description_with_language_fallback` | Descriptions |
+| 33 | POST | `/v1/entities/items/{item_id}/aliases/{language_code}` | `post_item_aliases` | Aliases |
+| 34 | POST | `/v1/entities/items/{item_id}/statements` | `post_item_statement` | Statements |
+| 35 | POST | `/v1/entities/properties` | `post_property` | Properties |
+| 36 | POST | `/v1/entities/properties/{property_id}/aliases/{language_code}` | `post_property_aliases` | Aliases |
+| 37 | POST | `/v1/entities/properties/{property_id}/statements` | `post_property_statement` | Statements |
+| 38 | PUT | `/v1/entities/items/{item_id}/labels/{language_code}` | `put_item_label` | Labels |
+| 39 | PUT | `/v1/entities/properties/{property_id}/labels/{language_code}` | `put_property_label` | Labels |
+| 40 | PUT | `/v1/entities/items/{item_id}/descriptions/{language_code}` | `put_item_description` | Descriptions |
+| 41 | PUT | `/v1/entities/properties/{property_id}/descriptions/{language_code}` | `put_property_description` | Descriptions |
+| 42 | PUT | `/v1/entities/items/{item_id}/sitelinks/{site_id}` | `put_item_sitelink` | Sitelinks |
+| 43 | PUT | `/v1/entities/items/{item_id}/statements/{statement_id}` | `put_item_statement` | Statements |
+| 44 | PUT | `/v1/entities/properties/{property_id}/statements/{statement_id}` | `put_property_statement` | Statements |
+| 45 | PUT | `/v1/statements/{statement_id}` | `put_statement` | Statements |
 
-## Uncovered endpoints (35)
-
-### GET (2) — language fallback for descriptions
-
-| Path | Target module |
-|------|---------------|
-| `/v1/entities/items/{item_id}/descriptions_with_language_fallback/{language_code}` | Descriptions |
-| `/v1/entities/properties/{property_id}/descriptions_with_language_fallback/{language_code}` | Descriptions |
-
-### POST (5) — create sub-resources and properties
-
-| Path | Target module |
-|------|---------------|
-| `/v1/entities/items/{item_id}/aliases/{language_code}` | Aliases |
-| `/v1/entities/items/{item_id}/statements` | Statements |
-| `/v1/entities/properties` | Properties |
-| `/v1/entities/properties/{property_id}/aliases/{language_code}` | Aliases |
-| `/v1/entities/properties/{property_id}/statements` | Statements |
+## Uncovered endpoints (20)
 
 ### PATCH (12) — partial updates
 
@@ -74,19 +72,6 @@ All GET endpoints plus `POST /v1/entities/items` are implemented.
 | `/v1/entities/properties/{property_id}/aliases` | Aliases |
 | `/v1/entities/properties/{property_id}/descriptions` | Descriptions |
 | `/v1/entities/properties/{property_id}/labels` | Labels |
-| `/v1/entities/properties/{property_id}/statements/{statement_id}` | Statements |
-| `/v1/statements/{statement_id}` | Statements |
-
-### PUT (8) — full replacements
-
-| Path | Target module |
-|------|---------------|
-| `/v1/entities/items/{item_id}/descriptions/{language_code}` | Descriptions |
-| `/v1/entities/items/{item_id}/labels/{language_code}` | Labels |
-| `/v1/entities/items/{item_id}/sitelinks/{site_id}` | Sitelinks |
-| `/v1/entities/items/{item_id}/statements/{statement_id}` | Statements |
-| `/v1/entities/properties/{property_id}/descriptions/{language_code}` | Descriptions |
-| `/v1/entities/properties/{property_id}/labels/{language_code}` | Labels |
 | `/v1/entities/properties/{property_id}/statements/{statement_id}` | Statements |
 | `/v1/statements/{statement_id}` | Statements |
 

--- a/lib/wikidata_adaptor/rest_api/descriptions.rb
+++ b/lib/wikidata_adaptor/rest_api/descriptions.rb
@@ -69,6 +69,28 @@ module WikidataAdaptor
       def get_property_description_with_language_fallback(property_id, lang_code)
         get_json("#{endpoint}/v1/entities/properties/#{CGI.escape(property_id)}/descriptions_with_language_fallback/#{lang_code}")
       end
+
+      # Replace an Item's description in a specific language.
+      #
+      # @param [String] item_id The ID of the Item.
+      # @param [String] lang_code The language code.
+      # @param [Hash] payload Description value and edit metadata.
+      #
+      # @return [String] The new description value.
+      def put_item_description(item_id, lang_code, payload)
+        put_json("#{endpoint}/v1/entities/items/#{CGI.escape(item_id)}/descriptions/#{lang_code}", payload)
+      end
+
+      # Replace a Property's description in a specific language.
+      #
+      # @param [String] property_id The ID of the Property.
+      # @param [String] lang_code The language code.
+      # @param [Hash] payload Description value and edit metadata.
+      #
+      # @return [String] The new description value.
+      def put_property_description(property_id, lang_code, payload)
+        put_json("#{endpoint}/v1/entities/properties/#{CGI.escape(property_id)}/descriptions/#{lang_code}", payload)
+      end
     end
   end
 end

--- a/lib/wikidata_adaptor/rest_api/labels.rb
+++ b/lib/wikidata_adaptor/rest_api/labels.rb
@@ -69,6 +69,28 @@ module WikidataAdaptor
       def get_property_label_with_language_fallback(property_id, lang_code)
         get_json("#{endpoint}/v1/entities/properties/#{CGI.escape(property_id)}/labels_with_language_fallback/#{lang_code}")
       end
+
+      # Replace an Item's label in a specific language.
+      #
+      # @param [String] item_id The ID of the Item.
+      # @param [String] lang_code The language code.
+      # @param [Hash] payload Label value and edit metadata.
+      #
+      # @return [String] The new label value.
+      def put_item_label(item_id, lang_code, payload)
+        put_json("#{endpoint}/v1/entities/items/#{CGI.escape(item_id)}/labels/#{lang_code}", payload)
+      end
+
+      # Replace a Property's label in a specific language.
+      #
+      # @param [String] property_id The ID of the Property.
+      # @param [String] lang_code The language code.
+      # @param [Hash] payload Label value and edit metadata.
+      #
+      # @return [String] The new label value.
+      def put_property_label(property_id, lang_code, payload)
+        put_json("#{endpoint}/v1/entities/properties/#{CGI.escape(property_id)}/labels/#{lang_code}", payload)
+      end
     end
   end
 end

--- a/lib/wikidata_adaptor/rest_api/sitelinks.rb
+++ b/lib/wikidata_adaptor/rest_api/sitelinks.rb
@@ -22,6 +22,17 @@ module WikidataAdaptor
       def get_item_sitelink(item_id, site_id)
         get_json("#{endpoint}/v1/entities/items/#{CGI.escape(item_id)}/sitelinks/#{CGI.escape(site_id)}")
       end
+
+      # Replace an Item's sitelink for a specific site.
+      #
+      # @param [String] item_id The ID of the Item.
+      # @param [String] site_id The site identifier (e.g., 'enwiki').
+      # @param [Hash] payload Sitelink value and edit metadata.
+      #
+      # @return [Hash] The new sitelink.
+      def put_item_sitelink(item_id, site_id, payload)
+        put_json("#{endpoint}/v1/entities/items/#{CGI.escape(item_id)}/sitelinks/#{CGI.escape(site_id)}", payload)
+      end
     end
   end
 end

--- a/lib/wikidata_adaptor/rest_api/statements.rb
+++ b/lib/wikidata_adaptor/rest_api/statements.rb
@@ -52,6 +52,38 @@ module WikidataAdaptor
       def post_property_statement(property_id, payload)
         post_json("#{endpoint}/v1/entities/properties/#{CGI.escape(property_id)}/statements", payload)
       end
+
+      # Replace a Statement on an Item.
+      #
+      # @param [String] item_id The ID of the Item.
+      # @param [String] statement_id The Statement ID.
+      # @param [Hash] payload Statement and edit metadata.
+      #
+      # @return [Hash] The replaced Statement.
+      def put_item_statement(item_id, statement_id, payload)
+        put_json("#{endpoint}/v1/entities/items/#{CGI.escape(item_id)}/statements/#{statement_id}", payload)
+      end
+
+      # Replace a Statement on a Property.
+      #
+      # @param [String] property_id The ID of the Property.
+      # @param [String] statement_id The Statement ID.
+      # @param [Hash] payload Statement and edit metadata.
+      #
+      # @return [Hash] The replaced Statement.
+      def put_property_statement(property_id, statement_id, payload)
+        put_json("#{endpoint}/v1/entities/properties/#{CGI.escape(property_id)}/statements/#{statement_id}", payload)
+      end
+
+      # Replace a Statement (global).
+      #
+      # @param [String] statement_id The Statement ID.
+      # @param [Hash] payload Statement and edit metadata.
+      #
+      # @return [Hash] The replaced Statement.
+      def put_statement(statement_id, payload)
+        put_json("#{endpoint}/v1/statements/#{statement_id}", payload)
+      end
     end
   end
 end

--- a/lib/wikidata_adaptor/test_helpers/rest_api/descriptions.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/descriptions.rb
@@ -123,6 +123,50 @@ module WikidataAdaptor
             response_body: response_body
           )
         end
+
+        ################################################################
+        # PUT /v1/entities/items/:item_id/descriptions/:language_code
+        ################################################################
+        def stub_put_item_description(item_id, language_code, payload, response_body: nil)
+          stub_rest_api_request(
+            :put,
+            "/v1/entities/items/#{item_id}/descriptions/#{language_code}",
+            with: { body: payload.to_json },
+            response_body: response_body || payload["description"]
+          )
+        end
+
+        def stub_put_item_description_unexpected_error(item_id, language_code, payload)
+          stub_rest_api_request(
+            :put,
+            "/v1/entities/items/#{item_id}/descriptions/#{language_code}",
+            response_status: 500,
+            with: { body: payload.to_json },
+            response_body: { code: "unexpected-error", message: "Unexpected Error" }
+          )
+        end
+
+        ######################################################################
+        # PUT /v1/entities/properties/:property_id/descriptions/:language_code
+        ######################################################################
+        def stub_put_property_description(property_id, language_code, payload, response_body: nil)
+          stub_rest_api_request(
+            :put,
+            "/v1/entities/properties/#{property_id}/descriptions/#{language_code}",
+            with: { body: payload.to_json },
+            response_body: response_body || payload["description"]
+          )
+        end
+
+        def stub_put_property_description_unexpected_error(property_id, language_code, payload)
+          stub_rest_api_request(
+            :put,
+            "/v1/entities/properties/#{property_id}/descriptions/#{language_code}",
+            response_status: 500,
+            with: { body: payload.to_json },
+            response_body: { code: "unexpected-error", message: "Unexpected Error" }
+          )
+        end
       end
     end
   end

--- a/lib/wikidata_adaptor/test_helpers/rest_api/labels.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/labels.rb
@@ -123,6 +123,50 @@ module WikidataAdaptor
             response_body: response_body
           )
         end
+
+        ##########################################################
+        # PUT /v1/entities/items/:item_id/labels/:language_code
+        ##########################################################
+        def stub_put_item_label(item_id, language_code, payload, response_body: nil)
+          stub_rest_api_request(
+            :put,
+            "/v1/entities/items/#{item_id}/labels/#{language_code}",
+            with: { body: payload.to_json },
+            response_body: response_body || payload["label"]
+          )
+        end
+
+        def stub_put_item_label_unexpected_error(item_id, language_code, payload)
+          stub_rest_api_request(
+            :put,
+            "/v1/entities/items/#{item_id}/labels/#{language_code}",
+            response_status: 500,
+            with: { body: payload.to_json },
+            response_body: { code: "unexpected-error", message: "Unexpected Error" }
+          )
+        end
+
+        ################################################################
+        # PUT /v1/entities/properties/:property_id/labels/:language_code
+        ################################################################
+        def stub_put_property_label(property_id, language_code, payload, response_body: nil)
+          stub_rest_api_request(
+            :put,
+            "/v1/entities/properties/#{property_id}/labels/#{language_code}",
+            with: { body: payload.to_json },
+            response_body: response_body || payload["label"]
+          )
+        end
+
+        def stub_put_property_label_unexpected_error(property_id, language_code, payload)
+          stub_rest_api_request(
+            :put,
+            "/v1/entities/properties/#{property_id}/labels/#{language_code}",
+            response_status: 500,
+            with: { body: payload.to_json },
+            response_body: { code: "unexpected-error", message: "Unexpected Error" }
+          )
+        end
       end
     end
   end

--- a/lib/wikidata_adaptor/test_helpers/rest_api/sitelinks.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/sitelinks.rb
@@ -40,6 +40,32 @@ module WikidataAdaptor
             }
           )
         end
+
+        #####################################################
+        # PUT /v1/entities/items/:item_id/sitelinks/:site_id
+        #####################################################
+        def stub_put_item_sitelink(item_id, site_id, payload, response_body: nil)
+          stub_rest_api_request(
+            :put,
+            "/v1/entities/items/#{item_id}/sitelinks/#{site_id}",
+            with: { body: payload.to_json },
+            response_body: response_body || {
+              title: "Douglas Adams",
+              badges: [],
+              url: "https://en.wikipedia.org/wiki/Douglas_Adams"
+            }
+          )
+        end
+
+        def stub_put_item_sitelink_unexpected_error(item_id, site_id, payload)
+          stub_rest_api_request(
+            :put,
+            "/v1/entities/items/#{item_id}/sitelinks/#{site_id}",
+            response_status: 500,
+            with: { body: payload.to_json },
+            response_body: { code: "unexpected-error", message: "Unexpected Error" }
+          )
+        end
       end
     end
   end

--- a/lib/wikidata_adaptor/test_helpers/rest_api/statements.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/statements.rb
@@ -156,6 +156,93 @@ module WikidataAdaptor
             }
           )
         end
+
+        ############################################################
+        # PUT /v1/entities/items/:item_id/statements/:statement_id
+        ############################################################
+        def stub_put_item_statement(item_id, statement_id, payload, response_body: nil)
+          stub_rest_api_request(
+            :put,
+            "/v1/entities/items/#{item_id}/statements/#{statement_id}",
+            with: { body: payload.to_json },
+            response_body: response_body || {
+              id: statement_id.to_s,
+              rank: "normal",
+              property: { id: "P92", "data-type": "string" },
+              value: { content: "Updated goat", type: "value" },
+              qualifiers: [],
+              references: []
+            }
+          )
+        end
+
+        def stub_put_item_statement_unexpected_error(item_id, statement_id, payload)
+          stub_rest_api_request(
+            :put,
+            "/v1/entities/items/#{item_id}/statements/#{statement_id}",
+            response_status: 500,
+            with: { body: payload.to_json },
+            response_body: { code: "unexpected-error", message: "Unexpected Error" }
+          )
+        end
+
+        ##################################################################
+        # PUT /v1/entities/properties/:property_id/statements/:statement_id
+        ##################################################################
+        def stub_put_property_statement(property_id, statement_id, payload, response_body: nil)
+          stub_rest_api_request(
+            :put,
+            "/v1/entities/properties/#{property_id}/statements/#{statement_id}",
+            with: { body: payload.to_json },
+            response_body: response_body || {
+              id: statement_id.to_s,
+              rank: "normal",
+              property: { id: property_id.to_s, "data-type": "wikibase-item" },
+              value: { content: "Q42", type: "value" },
+              qualifiers: [],
+              references: []
+            }
+          )
+        end
+
+        def stub_put_property_statement_unexpected_error(property_id, statement_id, payload)
+          stub_rest_api_request(
+            :put,
+            "/v1/entities/properties/#{property_id}/statements/#{statement_id}",
+            response_status: 500,
+            with: { body: payload.to_json },
+            response_body: { code: "unexpected-error", message: "Unexpected Error" }
+          )
+        end
+
+        #####################################
+        # PUT /v1/statements/:statement_id
+        #####################################
+        def stub_put_statement(statement_id, payload, response_body: nil)
+          stub_rest_api_request(
+            :put,
+            "/v1/statements/#{statement_id}",
+            with: { body: payload.to_json },
+            response_body: response_body || {
+              id: statement_id.to_s,
+              rank: "normal",
+              property: { id: "P92", "data-type": "string" },
+              value: { content: "Updated goat", type: "value" },
+              qualifiers: [],
+              references: []
+            }
+          )
+        end
+
+        def stub_put_statement_unexpected_error(statement_id, payload)
+          stub_rest_api_request(
+            :put,
+            "/v1/statements/#{statement_id}",
+            response_status: 500,
+            with: { body: payload.to_json },
+            response_body: { code: "unexpected-error", message: "Unexpected Error" }
+          )
+        end
       end
     end
   end

--- a/spec/integration/descriptions_spec.rb
+++ b/spec/integration/descriptions_spec.rb
@@ -61,5 +61,43 @@ RSpec.describe "Descriptions", :integration do
         expect(result).to eq(@en_desc)
       end
     end
+
+    describe "#put_property_description" do
+      it "replaces a property description and returns the new value" do
+        new_desc = "Updated prop desc #{SecureRandom.hex(4)}"
+        payload = { "description" => new_desc, "comment" => "integration test" }
+        result = api_client.put_property_description(@property["id"], "en", payload).parsed_content
+
+        expect(result).to eq(new_desc)
+
+        fetched = api_client.get_property_description(@property["id"], "en").parsed_content
+        expect(fetched).to eq(new_desc)
+      end
+    end
+  end
+
+  describe "put item descriptions" do
+    before(:context) do
+      extend WikidataAdaptor::Integration::Helpers
+
+      @en_desc = "Desc to replace #{SecureRandom.hex(4)}"
+      @item = create_item!(
+        labels: { "en" => "Put desc item #{SecureRandom.hex(4)}" },
+        descriptions: { "en" => @en_desc }
+      )
+    end
+
+    describe "#put_item_description" do
+      it "replaces an item description and returns the new value" do
+        new_desc = "Updated item desc #{SecureRandom.hex(4)}"
+        payload = { "description" => new_desc, "comment" => "integration test" }
+        result = api_client.put_item_description(@item["id"], "en", payload).parsed_content
+
+        expect(result).to eq(new_desc)
+
+        fetched = api_client.get_item_description(@item["id"], "en").parsed_content
+        expect(fetched).to eq(new_desc)
+      end
+    end
   end
 end

--- a/spec/integration/labels_spec.rb
+++ b/spec/integration/labels_spec.rb
@@ -83,5 +83,39 @@ RSpec.describe "Labels", :integration do
         expect(result).to eq(@en_label)
       end
     end
+
+    describe "#put_property_label" do
+      it "replaces a property label and returns the new value" do
+        new_label = "Updated prop label #{SecureRandom.hex(4)}"
+        payload = { "label" => new_label, "comment" => "integration test" }
+        result = api_client.put_property_label(@property["id"], "en", payload).parsed_content
+
+        expect(result).to eq(new_label)
+
+        fetched = api_client.get_property_label(@property["id"], "en").parsed_content
+        expect(fetched).to eq(new_label)
+      end
+    end
+  end
+
+  describe "put item labels" do
+    before(:context) do
+      extend WikidataAdaptor::Integration::Helpers
+
+      @item = create_item!(labels: { "en" => "Put label item #{SecureRandom.hex(4)}" })
+    end
+
+    describe "#put_item_label" do
+      it "replaces an item label and returns the new value" do
+        new_label = "Updated item label #{SecureRandom.hex(4)}"
+        payload = { "label" => new_label, "comment" => "integration test" }
+        result = api_client.put_item_label(@item["id"], "en", payload).parsed_content
+
+        expect(result).to eq(new_label)
+
+        fetched = api_client.get_item_label(@item["id"], "en").parsed_content
+        expect(fetched).to eq(new_label)
+      end
+    end
   end
 end

--- a/spec/integration/sitelinks_spec.rb
+++ b/spec/integration/sitelinks_spec.rb
@@ -18,4 +18,10 @@ RSpec.describe "Sitelinks", :integration do
       expect(result).to be_a(Hash)
     end
   end
+
+  describe "#put_item_sitelink" do
+    it "is not testable without configured sites in Docker Wikibase" do
+      skip "Docker Wikibase does not have sites configured for sitelink testing"
+    end
+  end
 end

--- a/spec/integration/statements_spec.rb
+++ b/spec/integration/statements_spec.rb
@@ -42,6 +42,35 @@ RSpec.describe "Statements", :integration do
         expect(result["value"]["content"]).to eq("test value")
       end
     end
+
+    describe "#put_item_statement" do
+      it "replaces a statement on an item and returns it" do
+        create_payload = {
+          "statement" => {
+            "property" => { "id" => @string_property["id"] },
+            "value" => { "type" => "value", "content" => "original value" }
+          },
+          "comment" => "integration test: create for put"
+        }
+        created = api_client.post_item_statement(@item["id"], create_payload).parsed_content
+        stmt_id = created["id"]
+
+        put_payload = {
+          "statement" => {
+            "property" => { "id" => @string_property["id"] },
+            "value" => { "type" => "value", "content" => "replaced value" }
+          },
+          "comment" => "integration test: put"
+        }
+        result = api_client.put_item_statement(@item["id"], stmt_id, put_payload).parsed_content
+
+        expect(result["id"]).to eq(stmt_id)
+        expect(result["value"]["content"]).to eq("replaced value")
+
+        fetched = api_client.get_item_statement(@item["id"], stmt_id).parsed_content
+        expect(fetched["value"]["content"]).to eq("replaced value")
+      end
+    end
   end
 
   describe "property statements" do
@@ -79,6 +108,64 @@ RSpec.describe "Statements", :integration do
         expect(result["rank"]).to eq("normal")
         expect(result["property"]["id"]).to eq(@string_property["id"])
         expect(result["value"]["content"]).to eq("test value")
+      end
+    end
+
+    describe "#put_property_statement" do
+      it "replaces a statement on a property and returns it" do
+        create_payload = {
+          "statement" => {
+            "property" => { "id" => @string_property["id"] },
+            "value" => { "type" => "value", "content" => "original prop value" }
+          },
+          "comment" => "integration test: create for put"
+        }
+        created = api_client.post_property_statement(@property["id"], create_payload).parsed_content
+        stmt_id = created["id"]
+
+        put_payload = {
+          "statement" => {
+            "property" => { "id" => @string_property["id"] },
+            "value" => { "type" => "value", "content" => "replaced prop value" }
+          },
+          "comment" => "integration test: put"
+        }
+        result = api_client.put_property_statement(@property["id"], stmt_id, put_payload).parsed_content
+
+        expect(result["id"]).to eq(stmt_id)
+        expect(result["value"]["content"]).to eq("replaced prop value")
+
+        fetched = api_client.get_property_statement(@property["id"], stmt_id).parsed_content
+        expect(fetched["value"]["content"]).to eq("replaced prop value")
+      end
+    end
+
+    describe "#put_statement" do
+      it "replaces a statement by global statement_id and returns it" do
+        create_payload = {
+          "statement" => {
+            "property" => { "id" => @string_property["id"] },
+            "value" => { "type" => "value", "content" => "original global value" }
+          },
+          "comment" => "integration test: create for put_statement"
+        }
+        created = api_client.post_property_statement(@property["id"], create_payload).parsed_content
+        stmt_id = created["id"]
+
+        put_payload = {
+          "statement" => {
+            "property" => { "id" => @string_property["id"] },
+            "value" => { "type" => "value", "content" => "replaced global value" }
+          },
+          "comment" => "integration test: put_statement"
+        }
+        result = api_client.put_statement(stmt_id, put_payload).parsed_content
+
+        expect(result["id"]).to eq(stmt_id)
+        expect(result["value"]["content"]).to eq("replaced global value")
+
+        fetched = api_client.get_statement(stmt_id).parsed_content
+        expect(fetched["value"]["content"]).to eq("replaced global value")
       end
     end
   end

--- a/spec/wikidata_adaptor/rest_api/descriptions_spec.rb
+++ b/spec/wikidata_adaptor/rest_api/descriptions_spec.rb
@@ -89,4 +89,36 @@ RSpec.describe WikidataAdaptor::RestApi::Descriptions do
       end
     end
   end
+
+  describe "#put_item_description" do
+    let(:payload) { { "description" => "British author and screenwriter", "comment" => "Update description" } }
+
+    it "replaces an item description" do
+      stub_put_item_description(item_id, "en", payload)
+      expect(api_client.put_item_description(item_id, "en", payload).raw_response_body)
+        .to eq("British author and screenwriter")
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_put_item_description_unexpected_error(item_id, "en", payload)
+      expect { api_client.put_item_description(item_id, "en", payload) }
+        .to raise_error(ApiAdaptor::HTTPInternalServerError)
+    end
+  end
+
+  describe "#put_property_description" do
+    let(:payload) { { "description" => "class membership relation", "comment" => "Update description" } }
+
+    it "replaces a property description" do
+      stub_put_property_description(property_id, "en", payload)
+      expect(api_client.put_property_description(property_id, "en", payload).raw_response_body)
+        .to eq("class membership relation")
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_put_property_description_unexpected_error(property_id, "en", payload)
+      expect { api_client.put_property_description(property_id, "en", payload) }
+        .to raise_error(ApiAdaptor::HTTPInternalServerError)
+    end
+  end
 end

--- a/spec/wikidata_adaptor/rest_api/labels_spec.rb
+++ b/spec/wikidata_adaptor/rest_api/labels_spec.rb
@@ -83,4 +83,36 @@ RSpec.describe WikidataAdaptor::RestApi::Labels do
       end
     end
   end
+
+  describe "#put_item_label" do
+    let(:payload) { { "label" => "Douglas Noel Adams", "comment" => "Update label" } }
+
+    it "replaces an item label" do
+      stub_put_item_label(item_id, "en", payload)
+      expect(api_client.put_item_label(item_id, "en", payload).raw_response_body)
+        .to eq("Douglas Noel Adams")
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_put_item_label_unexpected_error(item_id, "en", payload)
+      expect { api_client.put_item_label(item_id, "en", payload) }
+        .to raise_error(ApiAdaptor::HTTPInternalServerError)
+    end
+  end
+
+  describe "#put_property_label" do
+    let(:payload) { { "label" => "is an instance of", "comment" => "Update label" } }
+
+    it "replaces a property label" do
+      stub_put_property_label(property_id, "en", payload)
+      expect(api_client.put_property_label(property_id, "en", payload).raw_response_body)
+        .to eq("is an instance of")
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_put_property_label_unexpected_error(property_id, "en", payload)
+      expect { api_client.put_property_label(property_id, "en", payload) }
+        .to raise_error(ApiAdaptor::HTTPInternalServerError)
+    end
+  end
 end

--- a/spec/wikidata_adaptor/rest_api/sitelinks_spec.rb
+++ b/spec/wikidata_adaptor/rest_api/sitelinks_spec.rb
@@ -61,4 +61,26 @@ RSpec.describe WikidataAdaptor::RestApi::Sitelinks do
                })
     end
   end
+
+  describe "#put_item_sitelink" do
+    let(:site_id) { "enwiki" }
+    let(:payload) do
+      {
+        "sitelink" => { "title" => "Douglas Adams", "badges" => [] },
+        "comment" => "Set sitelink"
+      }
+    end
+
+    it "replaces a sitelink for an item" do
+      stub_put_item_sitelink(item_id, site_id, payload)
+      expect(api_client.put_item_sitelink(item_id, site_id, payload).parsed_content)
+        .to include("title" => "Douglas Adams")
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_put_item_sitelink_unexpected_error(item_id, site_id, payload)
+      expect { api_client.put_item_sitelink(item_id, site_id, payload) }
+        .to raise_error(ApiAdaptor::HTTPInternalServerError)
+    end
+  end
 end

--- a/spec/wikidata_adaptor/rest_api/statements_spec.rb
+++ b/spec/wikidata_adaptor/rest_api/statements_spec.rb
@@ -155,4 +155,77 @@ RSpec.describe WikidataAdaptor::RestApi::Statements do
       expect { api_client.post_property_statement(property_id, payload) }.to raise_error(ApiAdaptor::HTTPInternalServerError)
     end
   end
+
+  describe "#put_item_statement" do
+    let(:payload) do
+      {
+        "statement" => {
+          "property" => { "id" => "P92" },
+          "value" => { "type" => "value", "content" => "Updated goat" }
+        },
+        "comment" => "Replace statement"
+      }
+    end
+
+    it "replaces a statement on an item" do
+      stub_put_item_statement(item_id, statement_id, payload)
+      response = api_client.put_item_statement(item_id, statement_id, payload).parsed_content
+      expect(response).to include("id" => statement_id, "rank" => "normal")
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_put_item_statement_unexpected_error(item_id, statement_id, payload)
+      expect { api_client.put_item_statement(item_id, statement_id, payload) }
+        .to raise_error(ApiAdaptor::HTTPInternalServerError)
+    end
+  end
+
+  describe "#put_property_statement" do
+    let(:property_statement_id) { "P31$11111111-2222-3333-4444-555555555555" }
+    let(:payload) do
+      {
+        "statement" => {
+          "property" => { "id" => property_id },
+          "value" => { "type" => "value", "content" => "Q42" }
+        },
+        "comment" => "Replace statement"
+      }
+    end
+
+    it "replaces a statement on a property" do
+      stub_put_property_statement(property_id, property_statement_id, payload)
+      response = api_client.put_property_statement(property_id, property_statement_id, payload).parsed_content
+      expect(response).to include("id" => property_statement_id, "rank" => "normal")
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_put_property_statement_unexpected_error(property_id, property_statement_id, payload)
+      expect { api_client.put_property_statement(property_id, property_statement_id, payload) }
+        .to raise_error(ApiAdaptor::HTTPInternalServerError)
+    end
+  end
+
+  describe "#put_statement" do
+    let(:payload) do
+      {
+        "statement" => {
+          "property" => { "id" => "P92" },
+          "value" => { "type" => "value", "content" => "Updated goat" }
+        },
+        "comment" => "Replace statement"
+      }
+    end
+
+    it "replaces a statement by statement_id" do
+      stub_put_statement(statement_id, payload)
+      response = api_client.put_statement(statement_id, payload).parsed_content
+      expect(response).to include("id" => statement_id, "rank" => "normal")
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_put_statement_unexpected_error(statement_id, payload)
+      expect { api_client.put_statement(statement_id, payload) }
+        .to raise_error(ApiAdaptor::HTTPInternalServerError)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Adds 8 PUT endpoints (Phase 3) that replace a single resource with a new value, all requiring authentication
- Labels: `put_item_label`, `put_property_label`
- Descriptions: `put_item_description`, `put_property_description`
- Sitelinks: `put_item_sitelink`
- Statements: `put_item_statement`, `put_property_statement`, `put_statement`
- Adds TDD workflow documentation to CLAUDE.md
- API coverage moves from 30/65 (46%) to 38/65 (58%)

## Test plan

- [x] Unit tests pass (`bundle exec rspec` — 85 examples, 0 failures)
- [x] RuboCop passes (0 offenses)
- [ ] Integration tests against Docker Wikibase (`./script/integration-test`)
- [ ] Sitelink integration test is intentionally skipped (Docker Wikibase lacks configured sites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)