### PR TITLE
feat(patch): Add PATCH endpoints for JSON Patch updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@
   by site ID
 - PUT statement endpoints (`put_item_statement`,
   `put_property_statement`, `put_statement`) to replace statements
+- PATCH item and property endpoints (`patch_item`, `patch_property`)
+  for JSON Patch updates to entire entities
+- PATCH label endpoints (`patch_item_labels`, `patch_property_labels`)
+  for JSON Patch updates to labels
+- PATCH description endpoints (`patch_item_descriptions`,
+  `patch_property_descriptions`) for JSON Patch updates to descriptions
+- PATCH alias endpoints (`patch_item_aliases`, `patch_property_aliases`)
+  for JSON Patch updates to aliases
+- PATCH sitelinks endpoint (`patch_item_sitelinks`) for JSON Patch
+  updates to sitelinks
+- PATCH statement endpoints (`patch_item_statement`,
+  `patch_property_statement`, `patch_statement`) for JSON Patch updates
+  to statements
 - Search items (`search_items`, `suggest_items`) and search properties
   (`search_properties`) endpoints
 - Language fallback handling for labels via 307 redirect following

--- a/TODO.md
+++ b/TODO.md
@@ -2,11 +2,11 @@
 
 Tracking coverage of Wikibase REST API v1.4 (OpenAPI spec).
 
-**Covered: 45 / 65 endpoints (69%)**
+**Covered: 57 / 65 endpoints (88%)**
 
 ## Covered endpoints
 
-All GET, POST, and PUT endpoints are implemented.
+All GET, POST, PUT, and PATCH endpoints are implemented.
 
 | #   | Method | Path                                                                                        | Ruby method                                       | Module            |
 | --- | ------ | ------------------------------------------------------------------------------------------- | ------------------------------------------------- | ----------------- |
@@ -55,25 +55,20 @@ All GET, POST, and PUT endpoints are implemented.
 | 43  | PUT    | `/v1/entities/items/{item_id}/statements/{statement_id}`                                    | `put_item_statement`                              | Statements        |
 | 44  | PUT    | `/v1/entities/properties/{property_id}/statements/{statement_id}`                           | `put_property_statement`                          | Statements        |
 | 45  | PUT    | `/v1/statements/{statement_id}`                                                             | `put_statement`                                   | Statements        |
+| 46  | PATCH  | `/v1/entities/items/{item_id}`                                                              | `patch_item`                                      | Items             |
+| 47  | PATCH  | `/v1/entities/items/{item_id}/aliases`                                                      | `patch_item_aliases`                              | Aliases           |
+| 48  | PATCH  | `/v1/entities/items/{item_id}/descriptions`                                                 | `patch_item_descriptions`                         | Descriptions      |
+| 49  | PATCH  | `/v1/entities/items/{item_id}/labels`                                                       | `patch_item_labels`                               | Labels            |
+| 50  | PATCH  | `/v1/entities/items/{item_id}/sitelinks`                                                    | `patch_item_sitelinks`                            | Sitelinks         |
+| 51  | PATCH  | `/v1/entities/items/{item_id}/statements/{statement_id}`                                    | `patch_item_statement`                            | Statements        |
+| 52  | PATCH  | `/v1/entities/properties/{property_id}`                                                     | `patch_property`                                  | Properties        |
+| 53  | PATCH  | `/v1/entities/properties/{property_id}/aliases`                                             | `patch_property_aliases`                          | Aliases           |
+| 54  | PATCH  | `/v1/entities/properties/{property_id}/descriptions`                                        | `patch_property_descriptions`                     | Descriptions      |
+| 55  | PATCH  | `/v1/entities/properties/{property_id}/labels`                                              | `patch_property_labels`                           | Labels            |
+| 56  | PATCH  | `/v1/entities/properties/{property_id}/statements/{statement_id}`                           | `patch_property_statement`                        | Statements        |
+| 57  | PATCH  | `/v1/statements/{statement_id}`                                                             | `patch_statement`                                 | Statements        |
 
-## Uncovered endpoints (20)
-
-### PATCH (12) — partial updates
-
-| Path                                                              | Target module |
-| ----------------------------------------------------------------- | ------------- |
-| `/v1/entities/items/{item_id}`                                    | Items         |
-| `/v1/entities/items/{item_id}/aliases`                            | Aliases       |
-| `/v1/entities/items/{item_id}/descriptions`                       | Descriptions  |
-| `/v1/entities/items/{item_id}/labels`                             | Labels        |
-| `/v1/entities/items/{item_id}/sitelinks`                          | Sitelinks     |
-| `/v1/entities/items/{item_id}/statements/{statement_id}`          | Statements    |
-| `/v1/entities/properties/{property_id}`                           | Properties    |
-| `/v1/entities/properties/{property_id}/aliases`                   | Aliases       |
-| `/v1/entities/properties/{property_id}/descriptions`              | Descriptions  |
-| `/v1/entities/properties/{property_id}/labels`                    | Labels        |
-| `/v1/entities/properties/{property_id}/statements/{statement_id}` | Statements    |
-| `/v1/statements/{statement_id}`                                   | Statements    |
+## Uncovered endpoints (8)
 
 ### DELETE (8) — removals
 
@@ -117,16 +112,7 @@ Done
 
 ### Phase 4 — PATCH: partial updates (12 endpoints)
 
-Applies JSON Patch operations. Requires auth. Largest batch — consider
-splitting into sub-PRs per module.
-
-- Items: `patch_item`
-- Labels: `patch_item_labels`, `patch_property_labels`
-- Descriptions: `patch_item_descriptions`, `patch_property_descriptions`
-- Aliases: `patch_item_aliases`, `patch_property_aliases`
-- Sitelinks: `patch_item_sitelinks`
-- Statements: `patch_item_statement`, `patch_property_statement`, `patch_statement`
-- Properties: `patch_property`
+Done
 
 ### Phase 5 — DELETE: remove resources (8 endpoints)
 

--- a/lib/wikidata_adaptor/rest_api/aliases.rb
+++ b/lib/wikidata_adaptor/rest_api/aliases.rb
@@ -63,6 +63,26 @@ module WikidataAdaptor
       def post_property_aliases(property_id, lang_code, payload)
         post_json("#{endpoint}/v1/entities/properties/#{CGI.escape(property_id)}/aliases/#{lang_code}", payload)
       end
+
+      # Apply JSON Patch operations to an Item's aliases.
+      #
+      # @param [String] item_id The ID of the Item.
+      # @param [Hash] payload JSON Patch operations and edit metadata.
+      #
+      # @return [Hash] The updated aliases.
+      def patch_item_aliases(item_id, payload)
+        patch_json("#{endpoint}/v1/entities/items/#{CGI.escape(item_id)}/aliases", payload)
+      end
+
+      # Apply JSON Patch operations to a Property's aliases.
+      #
+      # @param [String] property_id The ID of the Property.
+      # @param [Hash] payload JSON Patch operations and edit metadata.
+      #
+      # @return [Hash] The updated aliases.
+      def patch_property_aliases(property_id, payload)
+        patch_json("#{endpoint}/v1/entities/properties/#{CGI.escape(property_id)}/aliases", payload)
+      end
     end
   end
 end

--- a/lib/wikidata_adaptor/rest_api/descriptions.rb
+++ b/lib/wikidata_adaptor/rest_api/descriptions.rb
@@ -91,6 +91,26 @@ module WikidataAdaptor
       def put_property_description(property_id, lang_code, payload)
         put_json("#{endpoint}/v1/entities/properties/#{CGI.escape(property_id)}/descriptions/#{lang_code}", payload)
       end
+
+      # Apply JSON Patch operations to an Item's descriptions.
+      #
+      # @param [String] item_id The ID of the Item.
+      # @param [Hash] payload JSON Patch operations and edit metadata.
+      #
+      # @return [Hash] The updated descriptions.
+      def patch_item_descriptions(item_id, payload)
+        patch_json("#{endpoint}/v1/entities/items/#{CGI.escape(item_id)}/descriptions", payload)
+      end
+
+      # Apply JSON Patch operations to a Property's descriptions.
+      #
+      # @param [String] property_id The ID of the Property.
+      # @param [Hash] payload JSON Patch operations and edit metadata.
+      #
+      # @return [Hash] The updated descriptions.
+      def patch_property_descriptions(property_id, payload)
+        patch_json("#{endpoint}/v1/entities/properties/#{CGI.escape(property_id)}/descriptions", payload)
+      end
     end
   end
 end

--- a/lib/wikidata_adaptor/rest_api/items.rb
+++ b/lib/wikidata_adaptor/rest_api/items.rb
@@ -21,6 +21,16 @@ module WikidataAdaptor
       def post_item(payload)
         post_json("#{endpoint}/v1/entities/items", payload)
       end
+
+      # Apply JSON Patch operations to an Item.
+      #
+      # @param [String] item_id The ID of the Item.
+      # @param [Hash] payload JSON Patch operations and edit metadata.
+      #
+      # @return [Hash] The updated Item.
+      def patch_item(item_id, payload)
+        patch_json("#{endpoint}/v1/entities/items/#{CGI.escape(item_id)}", payload)
+      end
     end
   end
 end

--- a/lib/wikidata_adaptor/rest_api/labels.rb
+++ b/lib/wikidata_adaptor/rest_api/labels.rb
@@ -91,6 +91,26 @@ module WikidataAdaptor
       def put_property_label(property_id, lang_code, payload)
         put_json("#{endpoint}/v1/entities/properties/#{CGI.escape(property_id)}/labels/#{lang_code}", payload)
       end
+
+      # Apply JSON Patch operations to an Item's labels.
+      #
+      # @param [String] item_id The ID of the Item.
+      # @param [Hash] payload JSON Patch operations and edit metadata.
+      #
+      # @return [Hash] The updated labels.
+      def patch_item_labels(item_id, payload)
+        patch_json("#{endpoint}/v1/entities/items/#{CGI.escape(item_id)}/labels", payload)
+      end
+
+      # Apply JSON Patch operations to a Property's labels.
+      #
+      # @param [String] property_id The ID of the Property.
+      # @param [Hash] payload JSON Patch operations and edit metadata.
+      #
+      # @return [Hash] The updated labels.
+      def patch_property_labels(property_id, payload)
+        patch_json("#{endpoint}/v1/entities/properties/#{CGI.escape(property_id)}/labels", payload)
+      end
     end
   end
 end

--- a/lib/wikidata_adaptor/rest_api/properties.rb
+++ b/lib/wikidata_adaptor/rest_api/properties.rb
@@ -21,6 +21,16 @@ module WikidataAdaptor
       def post_property(payload)
         post_json("#{endpoint}/v1/entities/properties", payload)
       end
+
+      # Apply JSON Patch operations to a Property.
+      #
+      # @param [String] property_id The ID of the Property.
+      # @param [Hash] payload JSON Patch operations and edit metadata.
+      #
+      # @return [Hash] The updated Property.
+      def patch_property(property_id, payload)
+        patch_json("#{endpoint}/v1/entities/properties/#{CGI.escape(property_id)}", payload)
+      end
     end
   end
 end

--- a/lib/wikidata_adaptor/rest_api/sitelinks.rb
+++ b/lib/wikidata_adaptor/rest_api/sitelinks.rb
@@ -33,6 +33,16 @@ module WikidataAdaptor
       def put_item_sitelink(item_id, site_id, payload)
         put_json("#{endpoint}/v1/entities/items/#{CGI.escape(item_id)}/sitelinks/#{CGI.escape(site_id)}", payload)
       end
+
+      # Apply JSON Patch operations to an Item's sitelinks.
+      #
+      # @param [String] item_id The ID of the Item.
+      # @param [Hash] payload JSON Patch operations and edit metadata.
+      #
+      # @return [Hash] The updated sitelinks.
+      def patch_item_sitelinks(item_id, payload)
+        patch_json("#{endpoint}/v1/entities/items/#{CGI.escape(item_id)}/sitelinks", payload)
+      end
     end
   end
 end

--- a/lib/wikidata_adaptor/rest_api/statements.rb
+++ b/lib/wikidata_adaptor/rest_api/statements.rb
@@ -84,6 +84,38 @@ module WikidataAdaptor
       def put_statement(statement_id, payload)
         put_json("#{endpoint}/v1/statements/#{statement_id}", payload)
       end
+
+      # Apply JSON Patch operations to a Statement on an Item.
+      #
+      # @param [String] item_id The ID of the Item.
+      # @param [String] statement_id The Statement ID.
+      # @param [Hash] payload JSON Patch operations and edit metadata.
+      #
+      # @return [Hash] The updated Statement.
+      def patch_item_statement(item_id, statement_id, payload)
+        patch_json("#{endpoint}/v1/entities/items/#{CGI.escape(item_id)}/statements/#{statement_id}", payload)
+      end
+
+      # Apply JSON Patch operations to a Statement on a Property.
+      #
+      # @param [String] property_id The ID of the Property.
+      # @param [String] statement_id The Statement ID.
+      # @param [Hash] payload JSON Patch operations and edit metadata.
+      #
+      # @return [Hash] The updated Statement.
+      def patch_property_statement(property_id, statement_id, payload)
+        patch_json("#{endpoint}/v1/entities/properties/#{CGI.escape(property_id)}/statements/#{statement_id}", payload)
+      end
+
+      # Apply JSON Patch operations to a Statement (global).
+      #
+      # @param [String] statement_id The Statement ID.
+      # @param [Hash] payload JSON Patch operations and edit metadata.
+      #
+      # @return [Hash] The updated Statement.
+      def patch_statement(statement_id, payload)
+        patch_json("#{endpoint}/v1/statements/#{statement_id}", payload)
+      end
     end
   end
 end

--- a/lib/wikidata_adaptor/test_helpers/rest_api/aliases.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/aliases.rb
@@ -133,6 +133,53 @@ module WikidataAdaptor
             }
           )
         end
+
+        ###########################################
+        # PATCH /v1/entities/items/:item_id/aliases
+        ###########################################
+        def stub_patch_item_aliases(item_id, payload, response_body: nil)
+          stub_rest_api_request(
+            :patch,
+            "/v1/entities/items/#{item_id}/aliases",
+            with: { body: payload.to_json },
+            response_body: response_body || {
+              en: ["Douglas Noel Adams", "Douglas Noël Adams", "DNA"],
+              fr: ["Douglas Noel Adams"]
+            }
+          )
+        end
+
+        def stub_patch_item_aliases_unexpected_error(item_id, payload)
+          stub_rest_api_request(
+            :patch,
+            "/v1/entities/items/#{item_id}/aliases",
+            response_status: 500,
+            with: { body: payload.to_json },
+            response_body: { code: "unexpected-error", message: "Unexpected Error" }
+          )
+        end
+
+        #################################################
+        # PATCH /v1/entities/properties/:property_id/aliases
+        #################################################
+        def stub_patch_property_aliases(property_id, payload, response_body: nil)
+          stub_rest_api_request(
+            :patch,
+            "/v1/entities/properties/#{property_id}/aliases",
+            with: { body: payload.to_json },
+            response_body: response_body || { en: ["is a", "is an"], fr: ["est un"] }
+          )
+        end
+
+        def stub_patch_property_aliases_unexpected_error(property_id, payload)
+          stub_rest_api_request(
+            :patch,
+            "/v1/entities/properties/#{property_id}/aliases",
+            response_status: 500,
+            with: { body: payload.to_json },
+            response_body: { code: "unexpected-error", message: "Unexpected Error" }
+          )
+        end
       end
     end
   end

--- a/lib/wikidata_adaptor/test_helpers/rest_api/descriptions.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/descriptions.rb
@@ -167,6 +167,56 @@ module WikidataAdaptor
             response_body: { code: "unexpected-error", message: "Unexpected Error" }
           )
         end
+
+        ################################################
+        # PATCH /v1/entities/items/:item_id/descriptions
+        ################################################
+        def stub_patch_item_descriptions(item_id, payload, response_body: nil)
+          stub_rest_api_request(
+            :patch,
+            "/v1/entities/items/#{item_id}/descriptions",
+            with: { body: payload.to_json },
+            response_body: response_body || {
+              en: "British author",
+              fr: "écrivain de science-fiction et humoriste anglais"
+            }
+          )
+        end
+
+        def stub_patch_item_descriptions_unexpected_error(item_id, payload)
+          stub_rest_api_request(
+            :patch,
+            "/v1/entities/items/#{item_id}/descriptions",
+            response_status: 500,
+            with: { body: payload.to_json },
+            response_body: { code: "unexpected-error", message: "Unexpected Error" }
+          )
+        end
+
+        ######################################################
+        # PATCH /v1/entities/properties/:property_id/descriptions
+        ######################################################
+        def stub_patch_property_descriptions(property_id, payload, response_body: nil)
+          stub_rest_api_request(
+            :patch,
+            "/v1/entities/properties/#{property_id}/descriptions",
+            with: { body: payload.to_json },
+            response_body: response_body || {
+              en: "class membership",
+              fr: "classe dont ce sujet est un exemple particulier"
+            }
+          )
+        end
+
+        def stub_patch_property_descriptions_unexpected_error(property_id, payload)
+          stub_rest_api_request(
+            :patch,
+            "/v1/entities/properties/#{property_id}/descriptions",
+            response_status: 500,
+            with: { body: payload.to_json },
+            response_body: { code: "unexpected-error", message: "Unexpected Error" }
+          )
+        end
       end
     end
   end

--- a/lib/wikidata_adaptor/test_helpers/rest_api/items.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/items.rb
@@ -142,6 +142,30 @@ module WikidataAdaptor
             }
           )
         end
+
+        ################################
+        # PATCH /v1/entities/items/:item_id
+        ################################
+        def stub_patch_item(item_id, payload, response_body: nil)
+          stub_rest_api_request(
+            :patch,
+            "/v1/entities/items/#{item_id}",
+            with: { body: payload.to_json },
+            response_body: response_body || load_path_example(
+              "/v1/entities/items/{item_id}", "get"
+            )
+          )
+        end
+
+        def stub_patch_item_unexpected_error(item_id, payload)
+          stub_rest_api_request(
+            :patch,
+            "/v1/entities/items/#{item_id}",
+            response_status: 500,
+            with: { body: payload.to_json },
+            response_body: { code: "unexpected-error", message: "Unexpected Error" }
+          )
+        end
       end
     end
   end

--- a/lib/wikidata_adaptor/test_helpers/rest_api/labels.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/labels.rb
@@ -167,6 +167,50 @@ module WikidataAdaptor
             response_body: { code: "unexpected-error", message: "Unexpected Error" }
           )
         end
+
+        ##########################################
+        # PATCH /v1/entities/items/:item_id/labels
+        ##########################################
+        def stub_patch_item_labels(item_id, payload, response_body: nil)
+          stub_rest_api_request(
+            :patch,
+            "/v1/entities/items/#{item_id}/labels",
+            with: { body: payload.to_json },
+            response_body: response_body || { en: "Douglas Noel Adams", fr: "Douglas Adams" }
+          )
+        end
+
+        def stub_patch_item_labels_unexpected_error(item_id, payload)
+          stub_rest_api_request(
+            :patch,
+            "/v1/entities/items/#{item_id}/labels",
+            response_status: 500,
+            with: { body: payload.to_json },
+            response_body: { code: "unexpected-error", message: "Unexpected Error" }
+          )
+        end
+
+        ################################################
+        # PATCH /v1/entities/properties/:property_id/labels
+        ################################################
+        def stub_patch_property_labels(property_id, payload, response_body: nil)
+          stub_rest_api_request(
+            :patch,
+            "/v1/entities/properties/#{property_id}/labels",
+            with: { body: payload.to_json },
+            response_body: response_body || { en: "is instance of", fr: "est un(e)" }
+          )
+        end
+
+        def stub_patch_property_labels_unexpected_error(property_id, payload)
+          stub_rest_api_request(
+            :patch,
+            "/v1/entities/properties/#{property_id}/labels",
+            response_status: 500,
+            with: { body: payload.to_json },
+            response_body: { code: "unexpected-error", message: "Unexpected Error" }
+          )
+        end
       end
     end
   end

--- a/lib/wikidata_adaptor/test_helpers/rest_api/properties.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/properties.rb
@@ -156,6 +156,36 @@ module WikidataAdaptor
             }
           )
         end
+
+        ##########################################
+        # PATCH /v1/entities/properties/:property_id
+        ##########################################
+        def stub_patch_property(property_id, payload, response_body: nil)
+          stub_rest_api_request(
+            :patch,
+            "/v1/entities/properties/#{property_id}",
+            with: { body: payload.to_json },
+            response_body: response_body || {
+              id: property_id.to_s,
+              type: "property",
+              data_type: "string",
+              labels: { en: "is instance of" },
+              descriptions: { en: "that class of which this subject is a particular example and member" },
+              aliases: { en: ["is a"] },
+              statements: {}
+            }
+          )
+        end
+
+        def stub_patch_property_unexpected_error(property_id, payload)
+          stub_rest_api_request(
+            :patch,
+            "/v1/entities/properties/#{property_id}",
+            response_status: 500,
+            with: { body: payload.to_json },
+            response_body: { code: "unexpected-error", message: "Unexpected Error" }
+          )
+        end
       end
     end
   end

--- a/lib/wikidata_adaptor/test_helpers/rest_api/sitelinks.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/sitelinks.rb
@@ -66,6 +66,34 @@ module WikidataAdaptor
             response_body: { code: "unexpected-error", message: "Unexpected Error" }
           )
         end
+
+        #############################################
+        # PATCH /v1/entities/items/:item_id/sitelinks
+        #############################################
+        def stub_patch_item_sitelinks(item_id, payload, response_body: nil)
+          stub_rest_api_request(
+            :patch,
+            "/v1/entities/items/#{item_id}/sitelinks",
+            with: { body: payload.to_json },
+            response_body: response_body || {
+              enwiki: {
+                title: "Douglas Adams",
+                badges: [],
+                url: "https://en.wikipedia.org/wiki/Douglas_Adams"
+              }
+            }
+          )
+        end
+
+        def stub_patch_item_sitelinks_unexpected_error(item_id, payload)
+          stub_rest_api_request(
+            :patch,
+            "/v1/entities/items/#{item_id}/sitelinks",
+            response_status: 500,
+            with: { body: payload.to_json },
+            response_body: { code: "unexpected-error", message: "Unexpected Error" }
+          )
+        end
       end
     end
   end

--- a/lib/wikidata_adaptor/test_helpers/rest_api/statements.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/statements.rb
@@ -243,6 +243,93 @@ module WikidataAdaptor
             response_body: { code: "unexpected-error", message: "Unexpected Error" }
           )
         end
+
+        ##############################################################
+        # PATCH /v1/entities/items/:item_id/statements/:statement_id
+        ##############################################################
+        def stub_patch_item_statement(item_id, statement_id, payload, response_body: nil)
+          stub_rest_api_request(
+            :patch,
+            "/v1/entities/items/#{item_id}/statements/#{statement_id}",
+            with: { body: payload.to_json },
+            response_body: response_body || {
+              id: statement_id.to_s,
+              rank: "normal",
+              property: { id: "P92", "data-type": "string" },
+              value: { content: "Patched goat", type: "value" },
+              qualifiers: [],
+              references: []
+            }
+          )
+        end
+
+        def stub_patch_item_statement_unexpected_error(item_id, statement_id, payload)
+          stub_rest_api_request(
+            :patch,
+            "/v1/entities/items/#{item_id}/statements/#{statement_id}",
+            response_status: 500,
+            with: { body: payload.to_json },
+            response_body: { code: "unexpected-error", message: "Unexpected Error" }
+          )
+        end
+
+        ####################################################################
+        # PATCH /v1/entities/properties/:property_id/statements/:statement_id
+        ####################################################################
+        def stub_patch_property_statement(property_id, statement_id, payload, response_body: nil)
+          stub_rest_api_request(
+            :patch,
+            "/v1/entities/properties/#{property_id}/statements/#{statement_id}",
+            with: { body: payload.to_json },
+            response_body: response_body || {
+              id: statement_id.to_s,
+              rank: "normal",
+              property: { id: property_id.to_s, "data-type": "wikibase-item" },
+              value: { content: "Q99", type: "value" },
+              qualifiers: [],
+              references: []
+            }
+          )
+        end
+
+        def stub_patch_property_statement_unexpected_error(property_id, statement_id, payload)
+          stub_rest_api_request(
+            :patch,
+            "/v1/entities/properties/#{property_id}/statements/#{statement_id}",
+            response_status: 500,
+            with: { body: payload.to_json },
+            response_body: { code: "unexpected-error", message: "Unexpected Error" }
+          )
+        end
+
+        #####################################
+        # PATCH /v1/statements/:statement_id
+        #####################################
+        def stub_patch_statement(statement_id, payload, response_body: nil)
+          stub_rest_api_request(
+            :patch,
+            "/v1/statements/#{statement_id}",
+            with: { body: payload.to_json },
+            response_body: response_body || {
+              id: statement_id.to_s,
+              rank: "normal",
+              property: { id: "P92", "data-type": "string" },
+              value: { content: "Patched goat", type: "value" },
+              qualifiers: [],
+              references: []
+            }
+          )
+        end
+
+        def stub_patch_statement_unexpected_error(statement_id, payload)
+          stub_rest_api_request(
+            :patch,
+            "/v1/statements/#{statement_id}",
+            response_status: 500,
+            with: { body: payload.to_json },
+            response_body: { code: "unexpected-error", message: "Unexpected Error" }
+          )
+        end
       end
     end
   end

--- a/spec/integration/aliases_spec.rb
+++ b/spec/integration/aliases_spec.rb
@@ -88,5 +88,42 @@ RSpec.describe "Aliases", :integration do
         expect(result).to include(new_alias)
       end
     end
+
+    describe "#patch_property_aliases" do
+      it "patches property aliases and returns the updated aliases" do
+        new_alias = "Patched prop alias #{SecureRandom.hex(4)}"
+        payload = {
+          "patch" => [{ "op" => "add", "path" => "/en/-", "value" => new_alias }],
+          "comment" => "integration test"
+        }
+        result = api_client.patch_property_aliases(@property["id"], payload).parsed_content
+
+        expect(result["en"]).to include(new_alias)
+      end
+    end
+  end
+
+  describe "patch item aliases" do
+    before(:context) do
+      extend WikidataAdaptor::Integration::Helpers
+
+      @item = create_item!(
+        labels: { "en" => "Patch alias item #{SecureRandom.hex(4)}" },
+        aliases: { "en" => ["Original alias #{SecureRandom.hex(4)}"] }
+      )
+    end
+
+    describe "#patch_item_aliases" do
+      it "patches item aliases and returns the updated aliases" do
+        new_alias = "Patched alias #{SecureRandom.hex(4)}"
+        payload = {
+          "patch" => [{ "op" => "add", "path" => "/en/-", "value" => new_alias }],
+          "comment" => "integration test"
+        }
+        result = api_client.patch_item_aliases(@item["id"], payload).parsed_content
+
+        expect(result["en"]).to include(new_alias)
+      end
+    end
   end
 end

--- a/spec/integration/descriptions_spec.rb
+++ b/spec/integration/descriptions_spec.rb
@@ -99,5 +99,42 @@ RSpec.describe "Descriptions", :integration do
         expect(fetched).to eq(new_desc)
       end
     end
+
+    describe "#patch_item_descriptions" do
+      it "patches item descriptions and returns the updated descriptions" do
+        new_desc = "Patched desc #{SecureRandom.hex(4)}"
+        payload = {
+          "patch" => [{ "op" => "replace", "path" => "/en", "value" => new_desc }],
+          "comment" => "integration test"
+        }
+        result = api_client.patch_item_descriptions(@item["id"], payload).parsed_content
+
+        expect(result["en"]).to eq(new_desc)
+      end
+    end
+  end
+
+  describe "patch property descriptions" do
+    before(:context) do
+      extend WikidataAdaptor::Integration::Helpers
+
+      @property = create_property!(
+        labels: { "en" => "Patch desc prop #{SecureRandom.hex(4)}" },
+        descriptions: { "en" => "Desc to patch #{SecureRandom.hex(4)}" }
+      )
+    end
+
+    describe "#patch_property_descriptions" do
+      it "patches property descriptions and returns the updated descriptions" do
+        new_desc = "Patched prop desc #{SecureRandom.hex(4)}"
+        payload = {
+          "patch" => [{ "op" => "replace", "path" => "/en", "value" => new_desc }],
+          "comment" => "integration test"
+        }
+        result = api_client.patch_property_descriptions(@property["id"], payload).parsed_content
+
+        expect(result["en"]).to eq(new_desc)
+      end
+    end
   end
 end

--- a/spec/integration/items_spec.rb
+++ b/spec/integration/items_spec.rb
@@ -46,4 +46,24 @@ RSpec.describe "Items", :integration do
       expect(result["descriptions"]).to include("en" => desc)
     end
   end
+
+  describe "#patch_item" do
+    before(:context) do
+      extend WikidataAdaptor::Integration::Helpers
+
+      @item = create_item!(labels: { "en" => "Patch item #{SecureRandom.hex(4)}" })
+    end
+
+    it "patches an item and returns the updated item" do
+      new_label = "Patched item #{SecureRandom.hex(4)}"
+      payload = {
+        "patch" => [{ "op" => "replace", "path" => "/labels/en", "value" => new_label }],
+        "comment" => "integration test"
+      }
+      result = api_client.patch_item(@item["id"], payload).parsed_content
+
+      expect(result["id"]).to eq(@item["id"])
+      expect(result["labels"]["en"]).to eq(new_label)
+    end
+  end
 end

--- a/spec/integration/labels_spec.rb
+++ b/spec/integration/labels_spec.rb
@@ -117,5 +117,39 @@ RSpec.describe "Labels", :integration do
         expect(fetched).to eq(new_label)
       end
     end
+
+    describe "#patch_item_labels" do
+      it "patches item labels and returns the updated labels" do
+        new_label = "Patched label #{SecureRandom.hex(4)}"
+        payload = {
+          "patch" => [{ "op" => "replace", "path" => "/en", "value" => new_label }],
+          "comment" => "integration test"
+        }
+        result = api_client.patch_item_labels(@item["id"], payload).parsed_content
+
+        expect(result["en"]).to eq(new_label)
+      end
+    end
+  end
+
+  describe "patch property labels" do
+    before(:context) do
+      extend WikidataAdaptor::Integration::Helpers
+
+      @property = create_property!(labels: { "en" => "Patch lbl prop #{SecureRandom.hex(4)}" })
+    end
+
+    describe "#patch_property_labels" do
+      it "patches property labels and returns the updated labels" do
+        new_label = "Patched prop label #{SecureRandom.hex(4)}"
+        payload = {
+          "patch" => [{ "op" => "replace", "path" => "/en", "value" => new_label }],
+          "comment" => "integration test"
+        }
+        result = api_client.patch_property_labels(@property["id"], payload).parsed_content
+
+        expect(result["en"]).to eq(new_label)
+      end
+    end
   end
 end

--- a/spec/integration/properties_spec.rb
+++ b/spec/integration/properties_spec.rb
@@ -55,4 +55,24 @@ RSpec.describe "Properties", :integration do
       expect(result["descriptions"]).to include("en" => desc)
     end
   end
+
+  describe "#patch_property" do
+    before(:context) do
+      extend WikidataAdaptor::Integration::Helpers
+
+      @property = create_property!(labels: { "en" => "Patch prop #{SecureRandom.hex(4)}" })
+    end
+
+    it "patches a property and returns the updated property" do
+      new_label = "Patched prop #{SecureRandom.hex(4)}"
+      payload = {
+        "patch" => [{ "op" => "replace", "path" => "/labels/en", "value" => new_label }],
+        "comment" => "integration test"
+      }
+      result = api_client.patch_property(@property["id"], payload).parsed_content
+
+      expect(result["id"]).to eq(@property["id"])
+      expect(result["labels"]["en"]).to eq(new_label)
+    end
+  end
 end

--- a/spec/integration/sitelinks_spec.rb
+++ b/spec/integration/sitelinks_spec.rb
@@ -21,7 +21,13 @@ RSpec.describe "Sitelinks", :integration do
 
   describe "#put_item_sitelink" do
     it "is not testable without configured sites in Docker Wikibase" do
-      skip "Docker Wikibase does not have sites configured for sitelink testing"
+      skip "Docker Wikibase does not have sites configured for put_item_sitelink testing"
+    end
+  end
+
+  describe "#patch_item_sitelinks" do
+    it "is not testable without configured sites in Docker Wikibase" do
+      skip "Docker Wikibase does not have sites configured for patch_item_sitelinks testing"
     end
   end
 end

--- a/spec/integration/statements_spec.rb
+++ b/spec/integration/statements_spec.rb
@@ -43,6 +43,29 @@ RSpec.describe "Statements", :integration do
       end
     end
 
+    describe "#patch_item_statement" do
+      it "patches a statement on an item and returns it" do
+        create_payload = {
+          "statement" => {
+            "property" => { "id" => @string_property["id"] },
+            "value" => { "type" => "value", "content" => "original patch value" }
+          },
+          "comment" => "integration test: create for patch"
+        }
+        created = api_client.post_item_statement(@item["id"], create_payload).parsed_content
+        stmt_id = created["id"]
+
+        patch_payload = {
+          "patch" => [{ "op" => "replace", "path" => "/value/content", "value" => "patched item value" }],
+          "comment" => "integration test: patch"
+        }
+        result = api_client.patch_item_statement(@item["id"], stmt_id, patch_payload).parsed_content
+
+        expect(result["id"]).to eq(stmt_id)
+        expect(result["value"]["content"]).to eq("patched item value")
+      end
+    end
+
     describe "#put_item_statement" do
       it "replaces a statement on an item and returns it" do
         create_payload = {
@@ -108,6 +131,52 @@ RSpec.describe "Statements", :integration do
         expect(result["rank"]).to eq("normal")
         expect(result["property"]["id"]).to eq(@string_property["id"])
         expect(result["value"]["content"]).to eq("test value")
+      end
+    end
+
+    describe "#patch_property_statement" do
+      it "patches a statement on a property and returns it" do
+        create_payload = {
+          "statement" => {
+            "property" => { "id" => @string_property["id"] },
+            "value" => { "type" => "value", "content" => "original patch prop value" }
+          },
+          "comment" => "integration test: create for patch"
+        }
+        created = api_client.post_property_statement(@property["id"], create_payload).parsed_content
+        stmt_id = created["id"]
+
+        patch_payload = {
+          "patch" => [{ "op" => "replace", "path" => "/value/content", "value" => "patched prop value" }],
+          "comment" => "integration test: patch"
+        }
+        result = api_client.patch_property_statement(@property["id"], stmt_id, patch_payload).parsed_content
+
+        expect(result["id"]).to eq(stmt_id)
+        expect(result["value"]["content"]).to eq("patched prop value")
+      end
+    end
+
+    describe "#patch_statement" do
+      it "patches a statement by global statement_id and returns it" do
+        create_payload = {
+          "statement" => {
+            "property" => { "id" => @string_property["id"] },
+            "value" => { "type" => "value", "content" => "original global patch value" }
+          },
+          "comment" => "integration test: create for patch_statement"
+        }
+        created = api_client.post_property_statement(@property["id"], create_payload).parsed_content
+        stmt_id = created["id"]
+
+        patch_payload = {
+          "patch" => [{ "op" => "replace", "path" => "/value/content", "value" => "patched global value" }],
+          "comment" => "integration test: patch_statement"
+        }
+        result = api_client.patch_statement(stmt_id, patch_payload).parsed_content
+
+        expect(result["id"]).to eq(stmt_id)
+        expect(result["value"]["content"]).to eq("patched global value")
       end
     end
 

--- a/spec/wikidata_adaptor/rest_api/aliases_spec.rb
+++ b/spec/wikidata_adaptor/rest_api/aliases_spec.rb
@@ -87,4 +87,46 @@ RSpec.describe WikidataAdaptor::RestApi::Aliases do
       expect { api_client.post_property_aliases(property_id, "en", payload) }.to raise_error(ApiAdaptor::HTTPInternalServerError)
     end
   end
+
+  describe "#patch_item_aliases" do
+    let(:payload) do
+      {
+        "patch" => [{ "op" => "add", "path" => "/en/-", "value" => "DNA" }],
+        "comment" => "Patch aliases"
+      }
+    end
+
+    it "patches item aliases and returns the updated aliases" do
+      stub_patch_item_aliases(item_id, payload)
+      expect(api_client.patch_item_aliases(item_id, payload).parsed_content)
+        .to include("en" => ["Douglas Noel Adams", "Douglas Noël Adams", "DNA"])
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_patch_item_aliases_unexpected_error(item_id, payload)
+      expect { api_client.patch_item_aliases(item_id, payload) }
+        .to raise_error(ApiAdaptor::HTTPInternalServerError)
+    end
+  end
+
+  describe "#patch_property_aliases" do
+    let(:payload) do
+      {
+        "patch" => [{ "op" => "add", "path" => "/en/-", "value" => "is an" }],
+        "comment" => "Patch aliases"
+      }
+    end
+
+    it "patches property aliases and returns the updated aliases" do
+      stub_patch_property_aliases(property_id, payload)
+      expect(api_client.patch_property_aliases(property_id, payload).parsed_content)
+        .to include("en" => ["is a", "is an"])
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_patch_property_aliases_unexpected_error(property_id, payload)
+      expect { api_client.patch_property_aliases(property_id, payload) }
+        .to raise_error(ApiAdaptor::HTTPInternalServerError)
+    end
+  end
 end

--- a/spec/wikidata_adaptor/rest_api/descriptions_spec.rb
+++ b/spec/wikidata_adaptor/rest_api/descriptions_spec.rb
@@ -121,4 +121,46 @@ RSpec.describe WikidataAdaptor::RestApi::Descriptions do
         .to raise_error(ApiAdaptor::HTTPInternalServerError)
     end
   end
+
+  describe "#patch_item_descriptions" do
+    let(:payload) do
+      {
+        "patch" => [{ "op" => "replace", "path" => "/en", "value" => "British author" }],
+        "comment" => "Patch descriptions"
+      }
+    end
+
+    it "patches item descriptions and returns the updated descriptions" do
+      stub_patch_item_descriptions(item_id, payload)
+      expect(api_client.patch_item_descriptions(item_id, payload).parsed_content)
+        .to include("en" => "British author")
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_patch_item_descriptions_unexpected_error(item_id, payload)
+      expect { api_client.patch_item_descriptions(item_id, payload) }
+        .to raise_error(ApiAdaptor::HTTPInternalServerError)
+    end
+  end
+
+  describe "#patch_property_descriptions" do
+    let(:payload) do
+      {
+        "patch" => [{ "op" => "replace", "path" => "/en", "value" => "class membership" }],
+        "comment" => "Patch descriptions"
+      }
+    end
+
+    it "patches property descriptions and returns the updated descriptions" do
+      stub_patch_property_descriptions(property_id, payload)
+      expect(api_client.patch_property_descriptions(property_id, payload).parsed_content)
+        .to include("en" => "class membership")
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_patch_property_descriptions_unexpected_error(property_id, payload)
+      expect { api_client.patch_property_descriptions(property_id, payload) }
+        .to raise_error(ApiAdaptor::HTTPInternalServerError)
+    end
+  end
 end

--- a/spec/wikidata_adaptor/rest_api/items_spec.rb
+++ b/spec/wikidata_adaptor/rest_api/items_spec.rb
@@ -70,4 +70,25 @@ RSpec.describe WikidataAdaptor::RestApi::Items do
       expect { api_client.post_item({}) }.to raise_error(ApiAdaptor::HTTPInternalServerError)
     end
   end
+
+  describe "#patch_item" do
+    let(:payload) do
+      {
+        "patch" => [{ "op" => "replace", "path" => "/labels/en", "value" => "Douglas Noel Adams" }],
+        "comment" => "Patch item"
+      }
+    end
+
+    it "patches an item and returns the updated item" do
+      stub_patch_item(item_id, payload)
+      response = api_client.patch_item(item_id, payload).parsed_content
+      expect(response.keys).to include("id", "type", "labels", "descriptions", "aliases", "statements", "sitelinks")
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_patch_item_unexpected_error(item_id, payload)
+      expect { api_client.patch_item(item_id, payload) }
+        .to raise_error(ApiAdaptor::HTTPInternalServerError)
+    end
+  end
 end

--- a/spec/wikidata_adaptor/rest_api/labels_spec.rb
+++ b/spec/wikidata_adaptor/rest_api/labels_spec.rb
@@ -115,4 +115,46 @@ RSpec.describe WikidataAdaptor::RestApi::Labels do
         .to raise_error(ApiAdaptor::HTTPInternalServerError)
     end
   end
+
+  describe "#patch_item_labels" do
+    let(:payload) do
+      {
+        "patch" => [{ "op" => "replace", "path" => "/en", "value" => "Douglas Noel Adams" }],
+        "comment" => "Patch labels"
+      }
+    end
+
+    it "patches item labels and returns the updated labels" do
+      stub_patch_item_labels(item_id, payload)
+      expect(api_client.patch_item_labels(item_id, payload).parsed_content)
+        .to include("en" => "Douglas Noel Adams")
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_patch_item_labels_unexpected_error(item_id, payload)
+      expect { api_client.patch_item_labels(item_id, payload) }
+        .to raise_error(ApiAdaptor::HTTPInternalServerError)
+    end
+  end
+
+  describe "#patch_property_labels" do
+    let(:payload) do
+      {
+        "patch" => [{ "op" => "replace", "path" => "/en", "value" => "is instance of" }],
+        "comment" => "Patch labels"
+      }
+    end
+
+    it "patches property labels and returns the updated labels" do
+      stub_patch_property_labels(property_id, payload)
+      expect(api_client.patch_property_labels(property_id, payload).parsed_content)
+        .to include("en" => "is instance of")
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_patch_property_labels_unexpected_error(property_id, payload)
+      expect { api_client.patch_property_labels(property_id, payload) }
+        .to raise_error(ApiAdaptor::HTTPInternalServerError)
+    end
+  end
 end

--- a/spec/wikidata_adaptor/rest_api/properties_spec.rb
+++ b/spec/wikidata_adaptor/rest_api/properties_spec.rb
@@ -68,4 +68,25 @@ RSpec.describe WikidataAdaptor::RestApi::Properties do
       expect { api_client.post_property({}) }.to raise_error(ApiAdaptor::HTTPInternalServerError)
     end
   end
+
+  describe "#patch_property" do
+    let(:payload) do
+      {
+        "patch" => [{ "op" => "replace", "path" => "/labels/en", "value" => "is instance of" }],
+        "comment" => "Patch property"
+      }
+    end
+
+    it "patches a property and returns the updated property" do
+      stub_patch_property(property_id, payload)
+      response = api_client.patch_property(property_id, payload).parsed_content
+      expect(response.keys).to include("id", "type", "labels", "descriptions", "aliases", "statements")
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_patch_property_unexpected_error(property_id, payload)
+      expect { api_client.patch_property(property_id, payload) }
+        .to raise_error(ApiAdaptor::HTTPInternalServerError)
+    end
+  end
 end

--- a/spec/wikidata_adaptor/rest_api/sitelinks_spec.rb
+++ b/spec/wikidata_adaptor/rest_api/sitelinks_spec.rb
@@ -83,4 +83,25 @@ RSpec.describe WikidataAdaptor::RestApi::Sitelinks do
         .to raise_error(ApiAdaptor::HTTPInternalServerError)
     end
   end
+
+  describe "#patch_item_sitelinks" do
+    let(:payload) do
+      {
+        "patch" => [{ "op" => "add", "path" => "/dewiki", "value" => { "title" => "Douglas Adams" } }],
+        "comment" => "Patch sitelinks"
+      }
+    end
+
+    it "patches item sitelinks and returns the updated sitelinks" do
+      stub_patch_item_sitelinks(item_id, payload)
+      expect(api_client.patch_item_sitelinks(item_id, payload).parsed_content)
+        .to include("enwiki")
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_patch_item_sitelinks_unexpected_error(item_id, payload)
+      expect { api_client.patch_item_sitelinks(item_id, payload) }
+        .to raise_error(ApiAdaptor::HTTPInternalServerError)
+    end
+  end
 end

--- a/spec/wikidata_adaptor/rest_api/statements_spec.rb
+++ b/spec/wikidata_adaptor/rest_api/statements_spec.rb
@@ -228,4 +228,68 @@ RSpec.describe WikidataAdaptor::RestApi::Statements do
         .to raise_error(ApiAdaptor::HTTPInternalServerError)
     end
   end
+
+  describe "#patch_item_statement" do
+    let(:payload) do
+      {
+        "patch" => [{ "op" => "replace", "path" => "/value/content", "value" => "Patched goat" }],
+        "comment" => "Patch statement"
+      }
+    end
+
+    it "patches a statement on an item" do
+      stub_patch_item_statement(item_id, statement_id, payload)
+      response = api_client.patch_item_statement(item_id, statement_id, payload).parsed_content
+      expect(response).to include("id" => statement_id, "rank" => "normal")
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_patch_item_statement_unexpected_error(item_id, statement_id, payload)
+      expect { api_client.patch_item_statement(item_id, statement_id, payload) }
+        .to raise_error(ApiAdaptor::HTTPInternalServerError)
+    end
+  end
+
+  describe "#patch_property_statement" do
+    let(:property_statement_id) { "P31$11111111-2222-3333-4444-555555555555" }
+    let(:payload) do
+      {
+        "patch" => [{ "op" => "replace", "path" => "/value/content", "value" => "Q99" }],
+        "comment" => "Patch statement"
+      }
+    end
+
+    it "patches a statement on a property" do
+      stub_patch_property_statement(property_id, property_statement_id, payload)
+      response = api_client.patch_property_statement(property_id, property_statement_id, payload).parsed_content
+      expect(response).to include("id" => property_statement_id, "rank" => "normal")
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_patch_property_statement_unexpected_error(property_id, property_statement_id, payload)
+      expect { api_client.patch_property_statement(property_id, property_statement_id, payload) }
+        .to raise_error(ApiAdaptor::HTTPInternalServerError)
+    end
+  end
+
+  describe "#patch_statement" do
+    let(:payload) do
+      {
+        "patch" => [{ "op" => "replace", "path" => "/value/content", "value" => "Patched goat" }],
+        "comment" => "Patch statement"
+      }
+    end
+
+    it "patches a statement by statement_id" do
+      stub_patch_statement(statement_id, payload)
+      response = api_client.patch_statement(statement_id, payload).parsed_content
+      expect(response).to include("id" => statement_id, "rank" => "normal")
+    end
+
+    it "raises a 500 response status if there's an unexpected error" do
+      stub_patch_statement_unexpected_error(statement_id, payload)
+      expect { api_client.patch_statement(statement_id, payload) }
+        .to raise_error(ApiAdaptor::HTTPInternalServerError)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Add 12 PATCH endpoints across all resource modules (items, properties, labels, descriptions, aliases, sitelinks, statements)
- All endpoints accept JSON Patch (RFC 6902) payloads via `patch_json` from ApiAdaptor::Base
- API coverage increases from 45/65 (69%) to 57/65 (88%) — only 8 DELETE endpoints remain

## Endpoints added

| Method | Ruby method | Module |
|--------|-------------|--------|
| `patch_item` | `patch_item(item_id, payload)` | Items |
| `patch_property` | `patch_property(property_id, payload)` | Properties |
| `patch_item_labels` | `patch_item_labels(item_id, payload)` | Labels |
| `patch_property_labels` | `patch_property_labels(property_id, payload)` | Labels |
| `patch_item_descriptions` | `patch_item_descriptions(item_id, payload)` | Descriptions |
| `patch_property_descriptions` | `patch_property_descriptions(property_id, payload)` | Descriptions |
| `patch_item_aliases` | `patch_item_aliases(item_id, payload)` | Aliases |
| `patch_property_aliases` | `patch_property_aliases(property_id, payload)` | Aliases |
| `patch_item_sitelinks` | `patch_item_sitelinks(item_id, payload)` | Sitelinks |
| `patch_item_statement` | `patch_item_statement(item_id, statement_id, payload)` | Statements |
| `patch_property_statement` | `patch_property_statement(property_id, statement_id, payload)` | Statements |
| `patch_statement` | `patch_statement(statement_id, payload)` | Statements |

## Commit structure (TDD)

1. **Unit tests (red)** — 24 tests across 7 spec files, calling methods that don't exist yet
2. **Stub helpers** — WebMock `stub_patch_*` helpers in all 7 test helper modules
3. **Implementation (green)** — 12 `patch_*` methods, all 109 unit tests pass
4. **Integration tests** — Tests against Docker Wikibase for all endpoints (sitelinks skipped — no sites configured)
5. **Docs** — TODO.md and CHANGELOG.md updated

## Test plan

- [x] `bundle exec rake` passes (109 examples, 0 failures, 0 RuboCop offenses)
- [ ] `./script/integration-test` against Docker Wikibase
- [ ] Verify sitelink PATCH tests are correctly skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)