### PR TITLE
fix(integration): Fix a race condition between PUT and fetch checks

### DIFF
--- a/spec/integration/descriptions_spec.rb
+++ b/spec/integration/descriptions_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe "Descriptions", :integration do
 
         expect(result).to eq(new_desc)
 
+        sleep(1)
         fetched = api_client.get_property_description(@property["id"], "en").parsed_content
         expect(fetched).to eq(new_desc)
       end
@@ -95,6 +96,7 @@ RSpec.describe "Descriptions", :integration do
 
         expect(result).to eq(new_desc)
 
+        sleep(1)
         fetched = api_client.get_item_description(@item["id"], "en").parsed_content
         expect(fetched).to eq(new_desc)
       end

--- a/spec/integration/descriptions_spec.rb
+++ b/spec/integration/descriptions_spec.rb
@@ -66,12 +66,13 @@ RSpec.describe "Descriptions", :integration do
       it "replaces a property description and returns the new value" do
         new_desc = "Updated prop desc #{SecureRandom.hex(4)}"
         payload = { "description" => new_desc, "comment" => "integration test" }
-        result = api_client.put_property_description(@property["id"], "en", payload).parsed_content
+        put_response = api_client.put_property_description(@property["id"], "en", payload)
 
-        expect(result).to eq(new_desc)
+        expect(put_response.parsed_content).to eq(new_desc)
 
-        sleep(1)
-        fetched = api_client.get_property_description(@property["id"], "en").parsed_content
+        fetched = wait_for_consistency(put_response) do
+          api_client.get_property_description(@property["id"], "en")
+        end
         expect(fetched).to eq(new_desc)
       end
     end
@@ -92,12 +93,13 @@ RSpec.describe "Descriptions", :integration do
       it "replaces an item description and returns the new value" do
         new_desc = "Updated item desc #{SecureRandom.hex(4)}"
         payload = { "description" => new_desc, "comment" => "integration test" }
-        result = api_client.put_item_description(@item["id"], "en", payload).parsed_content
+        put_response = api_client.put_item_description(@item["id"], "en", payload)
 
-        expect(result).to eq(new_desc)
+        expect(put_response.parsed_content).to eq(new_desc)
 
-        sleep(1)
-        fetched = api_client.get_item_description(@item["id"], "en").parsed_content
+        fetched = wait_for_consistency(put_response) do
+          api_client.get_item_description(@item["id"], "en")
+        end
         expect(fetched).to eq(new_desc)
       end
     end

--- a/spec/integration/labels_spec.rb
+++ b/spec/integration/labels_spec.rb
@@ -88,12 +88,13 @@ RSpec.describe "Labels", :integration do
       it "replaces a property label and returns the new value" do
         new_label = "Updated prop label #{SecureRandom.hex(4)}"
         payload = { "label" => new_label, "comment" => "integration test" }
-        result = api_client.put_property_label(@property["id"], "en", payload).parsed_content
+        put_response = api_client.put_property_label(@property["id"], "en", payload)
 
-        expect(result).to eq(new_label)
+        expect(put_response.parsed_content).to eq(new_label)
 
-        sleep(1)
-        fetched = api_client.get_property_label(@property["id"], "en").parsed_content
+        fetched = wait_for_consistency(put_response) do
+          api_client.get_property_label(@property["id"], "en")
+        end
         expect(fetched).to eq(new_label)
       end
     end
@@ -110,12 +111,13 @@ RSpec.describe "Labels", :integration do
       it "replaces an item label and returns the new value" do
         new_label = "Updated item label #{SecureRandom.hex(4)}"
         payload = { "label" => new_label, "comment" => "integration test" }
-        result = api_client.put_item_label(@item["id"], "en", payload).parsed_content
+        put_response = api_client.put_item_label(@item["id"], "en", payload)
 
-        expect(result).to eq(new_label)
+        expect(put_response.parsed_content).to eq(new_label)
 
-        sleep(1)
-        fetched = api_client.get_item_label(@item["id"], "en").parsed_content
+        fetched = wait_for_consistency(put_response) do
+          api_client.get_item_label(@item["id"], "en")
+        end
         expect(fetched).to eq(new_label)
       end
     end

--- a/spec/integration/labels_spec.rb
+++ b/spec/integration/labels_spec.rb
@@ -92,6 +92,7 @@ RSpec.describe "Labels", :integration do
 
         expect(result).to eq(new_label)
 
+        sleep(1)
         fetched = api_client.get_property_label(@property["id"], "en").parsed_content
         expect(fetched).to eq(new_label)
       end
@@ -113,6 +114,7 @@ RSpec.describe "Labels", :integration do
 
         expect(result).to eq(new_label)
 
+        sleep(1)
         fetched = api_client.get_item_label(@item["id"], "en").parsed_content
         expect(fetched).to eq(new_label)
       end


### PR DESCRIPTION
I don't like this sleep(1), it's not the solution, but I can't quite work out the signal to trigger a backoff. I think if we can figure it out then we should instead add something into the integration_helper so that we can call fetch, get an error and then backoff