### PR TITLE
Add comprehensive YARD documentation with automated publishing

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
         language: [ 'ruby' ]
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@9e907b5e64f6b83e7804b09294d44122997950d6 # v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           show-progress: false
 
@@ -37,7 +37,7 @@ jobs:
         run: bundle exec rake yard
 
       - name: Upload artifact for GitHub Pages
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: ./doc
 
@@ -53,4 +53,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,56 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+# Sets permissions for GitHub Pages deployment
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build YARD documentation
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+        with:
+          show-progress: false
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - name: Generate YARD documentation
+        run: bundle exec rake yard
+
+      - name: Upload artifact for GitHub Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./doc
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -17,7 +17,7 @@ jobs:
         ruby: ['3.2', '3.3', '3.4']
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           show-progress: false
 
@@ -39,7 +39,7 @@ jobs:
         ruby: ['3.2', '3.3', '3.4']
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           show-progress: false
 

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -49,3 +49,21 @@ jobs:
 
       - name: Run RSpec
         run: bundle exec rspec
+
+  docs-build:
+    name: YARD documentation build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+        with:
+          show-progress: false
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - name: Build YARD documentation
+        run: bundle exec rake yard

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 plugins:
   - rubocop-rake
   - rubocop-rspec
+  - rubocop-yard
 
 AllCops:
   NewCops: enable

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,10 @@
+--markup markdown
+--markup-provider redcarpet
+--output-dir doc
+--readme README.md
+--no-private
+--protected
+lib/**/*.rb
+-
+README.md
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,11 +51,19 @@ bundle exec rubocop
 - `WIKIBASE_BEARER_TOKEN` — Optional OAuth token for write operations
 - `INTEGRATION` — Set to `1` to include integration tests
 
+## Git Standards
+
+Never commit to main branch,
+Always create a new branch with a sensible descriptive name and expect a Pull Request process.
+
+You'll need to provide a good PR description that sums up any collected change.
+
 ## Commit Standards
 
 Follows [GDS Git conventions](https://gds-way.digital.cabinet-office.gov.uk/standards/source-code/working-with-git.html#commits), informed by [chris.beams.io/posts/git-commit](https://chris.beams.io/posts/git-commit), [thoughtbot](https://thoughtbot.com/blog/5-useful-tips-for-a-better-commit-message), [mislav.net](https://mislav.net/2014/02/hidden-documentation/), and [Joel Chippindale's "Telling Stories Through Your Commits"](https://blog.mocoso.co.uk/posts/talks/telling-stories-through-your-commits/).
 
 ### Formatting
+
 - **[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)** — subject line format: `<type>[optional scope]: <description>`
 - **Types**: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`
 - **Scope** — optional parenthetical context, e.g. `feat(labels):` or `fix(integration):`
@@ -65,23 +73,28 @@ Follows [GDS Git conventions](https://gds-way.digital.cabinet-office.gov.uk/stan
 - **Links supplement, not replace** — issue/PR links may go stale, so the message must stand on its own
 
 ### Content
+
 - **Answer three questions**: Why is this change necessary? How does it address the issue? What side effects does it have?
-- **Explain the "why"** — the code shows *how*; the commit message must capture *why*. Rationale and context are hard to reconstruct later
+- **Explain the "why"** — the code shows _how_; the commit message must capture _why_. Rationale and context are hard to reconstruct later
 - **Note alternatives considered** — if you chose approach A over B, say so and why
 
 ### Structure
+
 - **Atomic commits** — each commit is a self-contained, logical unit of work; avoid needing "and" in your subject line
 - **Tell a story** — commits should be logically ordered so the history reads as a coherent narrative, not a jumbled log
 - **Clean up before sharing** — revise commit history on feature branches before opening a PR
 
 ## Development Workflow (TDD)
 
-When adding new API endpoints, follow this test-driven approach:
+When adding new API endpoints, follow this test-driven approach.
+You are expected to pause and commit between each step, once we are ready for PR you may soft reset and re-commit if the audit history does not properly represent the above rules.
 
-1. **Write unit tests (red)** — Add `describe` blocks to the relevant spec file calling `stub_*` and API methods that don't exist yet. Verify `bundle exec rubocop` passes and `bundle exec rspec` fails.
-2. **Add test helpers + implementation (green)** — Add `stub_*` helpers and implement the API methods. Verify `bundle exec rake` passes (rspec + rubocop).
-3. **Add integration tests** — Add tests to `spec/integration/` that exercise the real API.
-4. **Update TODO** — Move endpoints from "Uncovered" to "Covered" in `TODO.md` and update counts.
+A good flow might look like:
+
+1. **Write unit tests (red)** — Add `describe` blocks to the relevant spec file calling `stub_*` and API methods that don't exist yet. Verify `bundle exec rubocop` passes and `bundle exec rspec` fails. Then commit and push.
+2. **Add test helpers + implementation (green)** — Add `stub_*` helpers and implement the API methods. Verify `bundle exec rake` passes (rspec + rubocop). Then commit and push.
+3. **Add integration tests** — Add tests to `spec/integration/` that exercise the real API. Then commit and push.
+4. **Update TODO** — Move endpoints from "Uncovered" to "Covered" in `TODO.md` and update counts. Then commit and push.
 
 ## Style
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,9 @@ gem "rspec", "~> 3.0"
 
 gem "rubocop-rake"
 gem "rubocop-rspec"
+gem "rubocop-yard"
 
 gem "dotenv", "3.2.0"
 gem "rubocop", "~> 1.84"
 gem "webmock", "~> 3.17"
+gem "yard", "~> 0.9"

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "rubocop-rspec"
 gem "rubocop-yard"
 
 gem "dotenv", "3.2.0"
+gem "redcarpet", "~> 3.6"
 gem "rubocop", "~> 1.84"
 gem "webmock", "~> 3.17"
 gem "yard", "~> 0.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ GEM
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.3.1)
+    redcarpet (3.6.1)
     regexp_parser (2.11.3)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
@@ -109,6 +110,7 @@ PLATFORMS
 DEPENDENCIES
   dotenv (= 3.2.0)
   rake (~> 13.0)
+  redcarpet (~> 3.6)
   rspec (~> 3.0)
   rubocop (~> 1.84)
   rubocop-rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,10 @@ GEM
     rubocop-rspec (3.9.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.81)
+    rubocop-yard (1.1.0)
+      lint_roller
+      rubocop (~> 1.72)
+      yard
     ruby-progressbar (1.13.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
@@ -96,6 +100,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    yard (0.9.38)
 
 PLATFORMS
   ruby
@@ -108,8 +113,10 @@ DEPENDENCIES
   rubocop (~> 1.84)
   rubocop-rake
   rubocop-rspec
+  rubocop-yard
   webmock (~> 3.17)
   wikidata_adaptor!
+  yard (~> 0.9)
 
 BUNDLED WITH
    2.5.4

--- a/Rakefile
+++ b/Rakefile
@@ -9,4 +9,12 @@ require "rubocop/rake_task"
 
 RuboCop::RakeTask.new
 
+require "yard"
+
+YARD::Rake::YardocTask.new do |t|
+  t.files = ["lib/**/*.rb"]
+  t.options = ["--output-dir", "doc", "--markup", "markdown"]
+  t.stats_options = ["--list-undoc"]
+end
+
 task default: %i[spec rubocop]

--- a/Rakefile
+++ b/Rakefile
@@ -11,9 +11,7 @@ RuboCop::RakeTask.new
 
 require "yard"
 
-YARD::Rake::YardocTask.new do |t|
-  t.files = ["lib/**/*.rb"]
-  t.options = ["--output-dir", "doc", "--markup", "markdown"]
+YARD::Rake::YardocTask.new(:yard) do |t|
   t.stats_options = ["--list-undoc"]
 end
 

--- a/TODO.md
+++ b/TODO.md
@@ -113,23 +113,45 @@ Done
 
 ## YARD Docs
 
-### Generate YARD documentation
+✅ **Complete** - All YARD documentation tasks finished.
 
-Add YARD and have it build API documentation (HTML by default; configure a Markdown formatter/plugin if Markdown output is required).
+### What was accomplished:
 
-### Format YARD headers
+1. **YARD tooling** ✅
+   - Added YARD gem (~> 0.9) for HTML documentation generation
+   - Added redcarpet gem (~> 3.6) for Markdown rendering
+   - Added rubocop-yard for YARD linting and standards enforcement
+   - Configured rubocop-yard plugin in `.rubocop.yml`
 
-Explore best practices for YARD headers, and consider bringing in linting tools.
-Establish best practices and check all covered docs.
-Amend the documentation module by module until the published docs align with best practices.
+2. **Documentation coverage** ✅
+   - Achieved 100% documentation coverage (193/193 methods)
+   - Documented all modules, classes, and constants
+   - Fixed YARD syntax errors (Array[String] → Array<String>)
+   - All documentation follows YARD best practices with proper @param and @return tags
 
-### Add pre-merge check to validate YARD headers
+3. **Development tools** ✅
+   - Added Rake task: `bundle exec rake yard`
+   - Created `.yardopts` configuration file for consistent settings
+   - Configured Markdown markup with redcarpet provider
+   - Included README.md and CLAUDE.md in generated docs
 
-Add a GitHub Action to validate that the YARD docs build succeeds and that headers meet linting standards pre-merge.
+4. **CI/CD automation** ✅
+   - GitHub Actions workflow for automated doc generation
+   - Automatic deployment to GitHub Pages on push to main
+   - Docs available at: https://huwd.github.io/wikidata_adaptor/
+   - Concurrency controls to prevent overlapping deployments
 
-### Serve the docs to a GitHub page held against the repo
+### Configuration notes:
 
-Add GitHub Actions to publish the YARD docs to the GitHub page held against the repo.
+- YARD configuration in `.yardopts` (single source of truth)
+- RuboCop YARD linting enabled (6 cops active)
+- Private methods excluded, protected methods included
+- Output directory: `doc/`
+- Markup: Markdown via redcarpet
+
+### GitHub Pages setup (one-time manual step):
+
+Go to repository Settings → Pages and set Source to "GitHub Actions".
 
 ## Publishing workflow
 

--- a/lib/wikidata_adaptor.rb
+++ b/lib/wikidata_adaptor.rb
@@ -6,8 +6,15 @@ require_relative "wikidata_adaptor/version"
 require_relative "wikidata_adaptor/rest_api"
 
 module WikidataAdaptor
+  # Base error class for WikidataAdaptor exceptions
   class Error < StandardError; end
 
+  # Get the Wikibase REST API endpoint URL
+  #
+  # Reads from the WIKIBASE_REST_ENDPOINT environment variable,
+  # defaulting to the production Wikidata endpoint.
+  #
+  # @return [String] The base URL for the Wikibase REST API
   def self.rest_endpoint
     ENV["WIKIBASE_REST_ENDPOINT"] || "https://www.wikidata.org/w/rest.php/wikibase"
   end

--- a/lib/wikidata_adaptor/rest_api/aliases.rb
+++ b/lib/wikidata_adaptor/rest_api/aliases.rb
@@ -18,7 +18,7 @@ module WikidataAdaptor
       # @param [String] item_id The ID of the required Item.
       # @param [String] lang_code The requested resource language.
       #
-      # @return [Array[String]] Item's alias in a specific language.
+      # @return [Array<String>] Item's alias in a specific language.
       def get_item_alias(item_id, lang_code)
         get_json("#{endpoint}/v1/entities/items/#{CGI.escape(item_id)}/aliases/#{lang_code}")
       end
@@ -48,7 +48,7 @@ module WikidataAdaptor
       # @param [String] property_id The ID of the required Property.
       # @param [String] lang_code The requested resource language.
       #
-      # @return [Array[String]] Property's aliases in a specific language.
+      # @return [Array<String>] Property's aliases in a specific language.
       def get_property_alias(property_id, lang_code)
         get_json("#{endpoint}/v1/entities/properties/#{CGI.escape(property_id)}/aliases/#{lang_code}")
       end

--- a/lib/wikidata_adaptor/test_helpers/rest_api.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api.rb
@@ -4,7 +4,22 @@ require "json"
 require "webmock"
 
 module WikidataAdaptor
+  # Test helpers for stubbing WikidataAdaptor API calls in tests
   module TestHelpers
+    # WebMock stubs for the Wikibase REST API
+    #
+    # Include this module in your RSpec tests to access stub methods
+    # for all Wikibase REST API endpoints.
+    #
+    # @example
+    #   RSpec.describe MyClass do
+    #     include WikidataAdaptor::TestHelpers::RestApi
+    #
+    #     it "fetches an item" do
+    #       stub_get_item("Q42")
+    #       # ...
+    #     end
+    #   end
     module RestApi
       require_relative "rest_api/open_api_document"
       require_relative "rest_api/aliases"
@@ -29,8 +44,23 @@ module WikidataAdaptor
       include WikidataAdaptor::TestHelpers::RestApi::SearchItem
       include WikidataAdaptor::TestHelpers::RestApi::SearchProperty
 
+      # Default test endpoint for stubbed requests
       WIKIBASE_REST_ENDPOINT = ENV["WIKIBASE_REST_ENDPOINT"] || "https://test.test/w/rest.php/wikibase"
 
+      # Stub a Wikibase REST API request with WebMock
+      #
+      # This is the base method used by all specific stub_* helpers.
+      # Use the specific stub methods instead of calling this directly.
+      #
+      # @param [Symbol] method HTTP method (:get, :post, :put, :patch, :delete)
+      # @param [String] path API path (e.g., "/v1/entities/items/Q42")
+      # @param [Hash] with Optional request matching criteria
+      # @param [Integer] response_status HTTP status code to return
+      # @param [Hash] response_headers HTTP headers to return
+      # @param [Hash, Array, String] response_body Response body
+      # @param [String, nil] session Optional session token
+      #
+      # @return [WebMock::RequestStub] The configured stub
       def stub_rest_api_request(method, path, with: {}, response_status: 200, response_headers: {}, response_body: {}, session: nil)
         with.merge!(headers: { WikidataAdaptor::RestApi::AUTH_HEADER_NAME => session }) if session
         session = nil if response_status >= 400

--- a/lib/wikidata_adaptor/test_helpers/rest_api/aliases.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/aliases.rb
@@ -3,6 +3,7 @@
 module WikidataAdaptor
   module TestHelpers
     module RestApi
+      # WebMock stubs for Wikibase REST API alias endpoints
       module Aliases
         ######################################
         # GET /v1/entities/items/:item_id/aliases
@@ -50,6 +51,14 @@ module WikidataAdaptor
           )
         end
 
+        # Stub POST item aliases request returning 201 Created
+        #
+        # @param [String] item_id The item ID
+        # @param [String] language_code The language code
+        # @param [Hash] payload The request payload
+        # @param [Array<String>, nil] response_body Optional custom response
+        #
+        # @return [WebMock::RequestStub]
         def stub_post_item_aliases_created(item_id, language_code, payload, response_body: nil)
           stub_rest_api_request(
             :post,
@@ -60,6 +69,13 @@ module WikidataAdaptor
           )
         end
 
+        # Stub POST item aliases request returning 500 error
+        #
+        # @param [String] item_id The item ID
+        # @param [String] language_code The language code
+        # @param [Hash] payload The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_post_item_aliases_unexpected_error(item_id, language_code, payload)
           stub_rest_api_request(
             :post,
@@ -111,6 +127,14 @@ module WikidataAdaptor
           )
         end
 
+        # Stub POST property aliases request returning 201 Created
+        #
+        # @param [String] property_id The property ID
+        # @param [String] language_code The language code
+        # @param [Hash] payload The request payload
+        # @param [Array<String>, nil] response_body Optional custom response
+        #
+        # @return [WebMock::RequestStub]
         def stub_post_property_aliases_created(property_id, language_code, payload, response_body: nil)
           stub_rest_api_request(
             :post,
@@ -121,6 +145,13 @@ module WikidataAdaptor
           )
         end
 
+        # Stub POST property aliases request returning 500 error
+        #
+        # @param [String] property_id The property ID
+        # @param [String] language_code The language code
+        # @param [Hash] payload The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_post_property_aliases_unexpected_error(property_id, language_code, payload)
           stub_rest_api_request(
             :post,
@@ -149,6 +180,12 @@ module WikidataAdaptor
           )
         end
 
+        # Stub PATCH item aliases request returning 500 error
+        #
+        # @param [String] item_id The item ID
+        # @param [Hash] payload The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_patch_item_aliases_unexpected_error(item_id, payload)
           stub_rest_api_request(
             :patch,
@@ -171,6 +208,12 @@ module WikidataAdaptor
           )
         end
 
+        # Stub PATCH property aliases request returning 500 error
+        #
+        # @param [String] property_id The property ID
+        # @param [Hash] payload The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_patch_property_aliases_unexpected_error(property_id, payload)
           stub_rest_api_request(
             :patch,

--- a/lib/wikidata_adaptor/test_helpers/rest_api/descriptions.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/descriptions.rb
@@ -3,6 +3,7 @@
 module WikidataAdaptor
   module TestHelpers
     module RestApi
+      # WebMock stubs for Wikibase REST API descriptions endpoints
       module Descriptions
         ###########################################
         # GET /v1/entities/items/:item_id/descriptions
@@ -136,6 +137,13 @@ module WikidataAdaptor
           )
         end
 
+        # Stub PUT item description request returning 500 error
+        #
+        # @param item_id [String] The item ID
+        # @param language_code [String] The language code
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_put_item_description_unexpected_error(item_id, language_code, payload)
           stub_rest_api_request(
             :put,
@@ -158,6 +166,13 @@ module WikidataAdaptor
           )
         end
 
+        # Stub PUT property description request returning 500 error
+        #
+        # @param property_id [String] The property ID
+        # @param language_code [String] The language code
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_put_property_description_unexpected_error(property_id, language_code, payload)
           stub_rest_api_request(
             :put,
@@ -183,6 +198,12 @@ module WikidataAdaptor
           )
         end
 
+        # Stub PATCH item descriptions request returning 500 error
+        #
+        # @param item_id [String] The item ID
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_patch_item_descriptions_unexpected_error(item_id, payload)
           stub_rest_api_request(
             :patch,
@@ -208,6 +229,12 @@ module WikidataAdaptor
           )
         end
 
+        # Stub PATCH property descriptions request returning 500 error
+        #
+        # @param property_id [String] The property ID
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_patch_property_descriptions_unexpected_error(property_id, payload)
           stub_rest_api_request(
             :patch,
@@ -230,6 +257,13 @@ module WikidataAdaptor
           )
         end
 
+        # Stub DELETE item description request returning 500 error
+        #
+        # @param item_id [String] The item ID
+        # @param language_code [String] The language code
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_delete_item_description_unexpected_error(item_id, language_code, payload)
           stub_rest_api_request(
             :delete,
@@ -252,6 +286,13 @@ module WikidataAdaptor
           )
         end
 
+        # Stub DELETE property description request returning 500 error
+        #
+        # @param property_id [String] The property ID
+        # @param language_code [String] The language code
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_delete_property_description_unexpected_error(property_id, language_code, payload)
           stub_rest_api_request(
             :delete,

--- a/lib/wikidata_adaptor/test_helpers/rest_api/items.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/items.rb
@@ -4,6 +4,7 @@ require_relative "support/support"
 module WikidataAdaptor
   module TestHelpers
     module RestApi
+      # WebMock stubs for Wikibase REST API items endpoints
       module Items
         include WikidataAdaptor::TestHelpers::RestApi::Support
 
@@ -20,6 +21,11 @@ module WikidataAdaptor
           )
         end
 
+        # Stub GET item request returning 400 invalid item error
+        #
+        # @param item_id [String] The item ID
+        #
+        # @return [WebMock::RequestStub]
         def stub_get_item_invalid_item(item_id)
           stub_rest_api_request(
             :get,
@@ -32,6 +38,11 @@ module WikidataAdaptor
           )
         end
 
+        # Stub GET item request returning 404 not found error
+        #
+        # @param item_id [String] The item ID
+        #
+        # @return [WebMock::RequestStub]
         def stub_get_item_not_found(item_id)
           stub_rest_api_request(
             :get,
@@ -44,6 +55,11 @@ module WikidataAdaptor
           )
         end
 
+        # Stub GET item request returning 500 error
+        #
+        # @param item_id [String] The item ID
+        #
+        # @return [WebMock::RequestStub]
         def stub_get_item_unexpected_error(item_id)
           stub_rest_api_request(
             :get,
@@ -69,6 +85,11 @@ module WikidataAdaptor
           )
         end
 
+        # Stub POST item request returning 400 invalid item error
+        #
+        # @param response_body [Hash, nil] Optional response body
+        #
+        # @return [WebMock::RequestStub]
         def stub_post_item_invalid_item(response_body = nil)
           stub_rest_api_request(
             :post,
@@ -81,6 +102,9 @@ module WikidataAdaptor
           )
         end
 
+        # Stub POST item request returning 403 access denied error
+        #
+        # @return [WebMock::RequestStub]
         def stub_post_item_access_denied
           stub_rest_api_request(
             :post,
@@ -97,6 +121,9 @@ module WikidataAdaptor
           )
         end
 
+        # Stub POST item request returning 422 data policy violation error
+        #
+        # @return [WebMock::RequestStub]
         def stub_post_item_data_policy_violation
           stub_rest_api_request(
             :post,
@@ -115,6 +142,9 @@ module WikidataAdaptor
           )
         end
 
+        # Stub POST item request returning 429 request limit reached error
+        #
+        # @return [WebMock::RequestStub]
         def stub_post_item_request_limit_reached
           stub_rest_api_request(
             :post,
@@ -130,6 +160,11 @@ module WikidataAdaptor
           )
         end
 
+        # Stub POST item request returning 500 error
+        #
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_post_item_unexpected_error(payload)
           stub_rest_api_request(
             :post,
@@ -157,6 +192,12 @@ module WikidataAdaptor
           )
         end
 
+        # Stub PATCH item request returning 500 error
+        #
+        # @param item_id [String] The item ID
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_patch_item_unexpected_error(item_id, payload)
           stub_rest_api_request(
             :patch,

--- a/lib/wikidata_adaptor/test_helpers/rest_api/labels.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/labels.rb
@@ -3,6 +3,7 @@
 module WikidataAdaptor
   module TestHelpers
     module RestApi
+      # WebMock stubs for Wikibase REST API labels endpoints
       module Labels
         #####################################
         # GET /v1/entities/items/:item_id/labels
@@ -136,6 +137,13 @@ module WikidataAdaptor
           )
         end
 
+        # Stub PUT item label request returning 500 error
+        #
+        # @param item_id [String] The item ID
+        # @param language_code [String] The language code
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_put_item_label_unexpected_error(item_id, language_code, payload)
           stub_rest_api_request(
             :put,
@@ -158,6 +166,13 @@ module WikidataAdaptor
           )
         end
 
+        # Stub PUT property label request returning 500 error
+        #
+        # @param property_id [String] The property ID
+        # @param language_code [String] The language code
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_put_property_label_unexpected_error(property_id, language_code, payload)
           stub_rest_api_request(
             :put,
@@ -180,6 +195,12 @@ module WikidataAdaptor
           )
         end
 
+        # Stub PATCH item labels request returning 500 error
+        #
+        # @param item_id [String] The item ID
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_patch_item_labels_unexpected_error(item_id, payload)
           stub_rest_api_request(
             :patch,
@@ -202,6 +223,12 @@ module WikidataAdaptor
           )
         end
 
+        # Stub PATCH property labels request returning 500 error
+        #
+        # @param property_id [String] The property ID
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_patch_property_labels_unexpected_error(property_id, payload)
           stub_rest_api_request(
             :patch,
@@ -224,6 +251,13 @@ module WikidataAdaptor
           )
         end
 
+        # Stub DELETE item label request returning 500 error
+        #
+        # @param item_id [String] The item ID
+        # @param language_code [String] The language code
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_delete_item_label_unexpected_error(item_id, language_code, payload)
           stub_rest_api_request(
             :delete,
@@ -246,6 +280,13 @@ module WikidataAdaptor
           )
         end
 
+        # Stub DELETE property label request returning 500 error
+        #
+        # @param property_id [String] The property ID
+        # @param language_code [String] The language code
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_delete_property_label_unexpected_error(property_id, language_code, payload)
           stub_rest_api_request(
             :delete,

--- a/lib/wikidata_adaptor/test_helpers/rest_api/properties.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/properties.rb
@@ -4,6 +4,7 @@ require_relative "support/support"
 module WikidataAdaptor
   module TestHelpers
     module RestApi
+      # WebMock stubs for Wikibase REST API properties endpoints
       module Properties
         include WikidataAdaptor::TestHelpers::RestApi::Support
 
@@ -34,6 +35,11 @@ module WikidataAdaptor
           )
         end
 
+        # Stub GET property request returning 400 invalid property error
+        #
+        # @param property_id [String] The property ID
+        #
+        # @return [WebMock::RequestStub]
         def stub_get_property_invalid_property(property_id)
           stub_rest_api_request(
             :get,
@@ -46,6 +52,11 @@ module WikidataAdaptor
           )
         end
 
+        # Stub GET property request returning 404 not found error
+        #
+        # @param property_id [String] The property ID
+        #
+        # @return [WebMock::RequestStub]
         def stub_get_property_not_found(property_id)
           stub_rest_api_request(
             :get,
@@ -58,6 +69,11 @@ module WikidataAdaptor
           )
         end
 
+        # Stub GET property request returning 500 error
+        #
+        # @param property_id [String] The property ID
+        #
+        # @return [WebMock::RequestStub]
         def stub_get_property_unexpected_error(property_id)
           stub_rest_api_request(
             :get,
@@ -83,6 +99,11 @@ module WikidataAdaptor
           )
         end
 
+        # Stub POST property request returning 400 invalid property error
+        #
+        # @param response_body [Hash, nil] Optional response body
+        #
+        # @return [WebMock::RequestStub]
         def stub_post_property_invalid_property(response_body = nil)
           stub_rest_api_request(
             :post,
@@ -95,6 +116,9 @@ module WikidataAdaptor
           )
         end
 
+        # Stub POST property request returning 403 access denied error
+        #
+        # @return [WebMock::RequestStub]
         def stub_post_property_access_denied
           stub_rest_api_request(
             :post,
@@ -111,6 +135,9 @@ module WikidataAdaptor
           )
         end
 
+        # Stub POST property request returning 422 data policy violation error
+        #
+        # @return [WebMock::RequestStub]
         def stub_post_property_data_policy_violation
           stub_rest_api_request(
             :post,
@@ -129,6 +156,9 @@ module WikidataAdaptor
           )
         end
 
+        # Stub POST property request returning 429 request limit reached error
+        #
+        # @return [WebMock::RequestStub]
         def stub_post_property_request_limit_reached
           stub_rest_api_request(
             :post,
@@ -144,6 +174,11 @@ module WikidataAdaptor
           )
         end
 
+        # Stub POST property request returning 500 error
+        #
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_post_property_unexpected_error(payload)
           stub_rest_api_request(
             :post,
@@ -177,6 +212,12 @@ module WikidataAdaptor
           )
         end
 
+        # Stub PATCH property request returning 500 error
+        #
+        # @param property_id [String] The property ID
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_patch_property_unexpected_error(property_id, payload)
           stub_rest_api_request(
             :patch,

--- a/lib/wikidata_adaptor/test_helpers/rest_api/search_item.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/search_item.rb
@@ -3,6 +3,7 @@
 module WikidataAdaptor
   module TestHelpers
     module RestApi
+      # WebMock stubs for Wikibase REST API item search endpoints
       module SearchItem
         ########################################
         # GET /v0/search/items

--- a/lib/wikidata_adaptor/test_helpers/rest_api/search_property.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/search_property.rb
@@ -3,6 +3,7 @@
 module WikidataAdaptor
   module TestHelpers
     module RestApi
+      # WebMock stubs for Wikibase REST API property search endpoints
       module SearchProperty
         ########################################
         # GET /v0/search/properties

--- a/lib/wikidata_adaptor/test_helpers/rest_api/sitelinks.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/sitelinks.rb
@@ -3,6 +3,7 @@
 module WikidataAdaptor
   module TestHelpers
     module RestApi
+      # WebMock stubs for Wikibase REST API sitelinks endpoints
       module Sitelinks
         ########################################
         # GET /v1/entities/items/:item_id/sitelinks
@@ -57,6 +58,13 @@ module WikidataAdaptor
           )
         end
 
+        # Stub PUT item sitelink request returning 500 error
+        #
+        # @param item_id [String] The item ID
+        # @param site_id [String] The site ID
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_put_item_sitelink_unexpected_error(item_id, site_id, payload)
           stub_rest_api_request(
             :put,
@@ -85,6 +93,12 @@ module WikidataAdaptor
           )
         end
 
+        # Stub PATCH item sitelinks request returning 500 error
+        #
+        # @param item_id [String] The item ID
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_patch_item_sitelinks_unexpected_error(item_id, payload)
           stub_rest_api_request(
             :patch,
@@ -107,6 +121,13 @@ module WikidataAdaptor
           )
         end
 
+        # Stub DELETE item sitelink request returning 500 error
+        #
+        # @param item_id [String] The item ID
+        # @param site_id [String] The site ID
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_delete_item_sitelink_unexpected_error(item_id, site_id, payload)
           stub_rest_api_request(
             :delete,

--- a/lib/wikidata_adaptor/test_helpers/rest_api/statements.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/statements.rb
@@ -3,6 +3,7 @@
 module WikidataAdaptor
   module TestHelpers
     module RestApi
+      # WebMock stubs for Wikibase REST API statements endpoints
       module Statements
         #########################################
         # GET /v1/entities/items/:item_id/statements
@@ -64,6 +65,12 @@ module WikidataAdaptor
           )
         end
 
+        # Stub POST item statement request returning 500 error
+        #
+        # @param item_id [String] The item ID
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_post_item_statement_unexpected_error(item_id, payload)
           stub_rest_api_request(
             :post,
@@ -144,6 +151,12 @@ module WikidataAdaptor
           )
         end
 
+        # Stub POST property statement request returning 500 error
+        #
+        # @param property_id [String] The property ID
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_post_property_statement_unexpected_error(property_id, payload)
           stub_rest_api_request(
             :post,
@@ -176,6 +189,13 @@ module WikidataAdaptor
           )
         end
 
+        # Stub PUT item statement request returning 500 error
+        #
+        # @param item_id [String] The item ID
+        # @param statement_id [String] The statement ID
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_put_item_statement_unexpected_error(item_id, statement_id, payload)
           stub_rest_api_request(
             :put,
@@ -205,6 +225,13 @@ module WikidataAdaptor
           )
         end
 
+        # Stub PUT property statement request returning 500 error
+        #
+        # @param property_id [String] The property ID
+        # @param statement_id [String] The statement ID
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_put_property_statement_unexpected_error(property_id, statement_id, payload)
           stub_rest_api_request(
             :put,
@@ -234,6 +261,12 @@ module WikidataAdaptor
           )
         end
 
+        # Stub PUT statement request returning 500 error
+        #
+        # @param statement_id [String] The statement ID
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_put_statement_unexpected_error(statement_id, payload)
           stub_rest_api_request(
             :put,
@@ -263,6 +296,13 @@ module WikidataAdaptor
           )
         end
 
+        # Stub PATCH item statement request returning 500 error
+        #
+        # @param item_id [String] The item ID
+        # @param statement_id [String] The statement ID
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_patch_item_statement_unexpected_error(item_id, statement_id, payload)
           stub_rest_api_request(
             :patch,
@@ -292,6 +332,13 @@ module WikidataAdaptor
           )
         end
 
+        # Stub PATCH property statement request returning 500 error
+        #
+        # @param property_id [String] The property ID
+        # @param statement_id [String] The statement ID
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_patch_property_statement_unexpected_error(property_id, statement_id, payload)
           stub_rest_api_request(
             :patch,
@@ -321,6 +368,12 @@ module WikidataAdaptor
           )
         end
 
+        # Stub PATCH statement request returning 500 error
+        #
+        # @param statement_id [String] The statement ID
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_patch_statement_unexpected_error(statement_id, payload)
           stub_rest_api_request(
             :patch,
@@ -343,6 +396,13 @@ module WikidataAdaptor
           )
         end
 
+        # Stub DELETE item statement request returning 500 error
+        #
+        # @param item_id [String] The item ID
+        # @param statement_id [String] The statement ID
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_delete_item_statement_unexpected_error(item_id, statement_id, payload)
           stub_rest_api_request(
             :delete,
@@ -365,6 +425,13 @@ module WikidataAdaptor
           )
         end
 
+        # Stub DELETE property statement request returning 500 error
+        #
+        # @param property_id [String] The property ID
+        # @param statement_id [String] The statement ID
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_delete_property_statement_unexpected_error(property_id, statement_id, payload)
           stub_rest_api_request(
             :delete,
@@ -387,6 +454,12 @@ module WikidataAdaptor
           )
         end
 
+        # Stub DELETE statement request returning 500 error
+        #
+        # @param statement_id [String] The statement ID
+        # @param payload [Hash] The request payload
+        #
+        # @return [WebMock::RequestStub]
         def stub_delete_statement_unexpected_error(statement_id, payload)
           stub_rest_api_request(
             :delete,

--- a/lib/wikidata_adaptor/test_helpers/rest_api/support/support.rb
+++ b/lib/wikidata_adaptor/test_helpers/rest_api/support/support.rb
@@ -3,13 +3,24 @@
 module WikidataAdaptor
   module TestHelpers
     module RestApi
+      # WebMock stubs for Wikibase REST API support utilities
       module Support
+        # Load the OpenAPI specification from file
+        #
+        # @return [Hash] The parsed OpenAPI specification
         def load_openapi_spec
           JSON.parse(
             File.read(File.join("spec", "openapi", "openapi.json"))
           )
         end
 
+        # Load example response from OpenAPI specification for a given path and method
+        #
+        # @param path [String] The API path
+        # @param method [String] The HTTP method
+        # @param response_code [String] The HTTP response code
+        #
+        # @return [Hash] The example response
         def load_path_example(path, method, response_code = "200")
           load_openapi_spec.dig(
             "paths",
@@ -23,6 +34,9 @@ module WikidataAdaptor
           )
         end
 
+        # Fixture for a posted item response
+        #
+        # @return [Hash] The posted item response fixture
         def posted_item_response_fixture
           {
             "id" => "Q24",
@@ -144,6 +158,9 @@ module WikidataAdaptor
           }
         end
 
+        # Fixture for a posted property response
+        #
+        # @return [Hash] The posted property response fixture
         def posted_property_response_fixture
           {
             "id" => "P1",
@@ -162,6 +179,9 @@ module WikidataAdaptor
           }
         end
 
+        # Fixture for a property creation payload
+        #
+        # @return [Hash] The posted property payload fixture
         def posted_property_payload_fixture
           {
             "property" => {
@@ -180,6 +200,9 @@ module WikidataAdaptor
           }
         end
 
+        # Fixture for an item creation payload
+        #
+        # @return [Hash] The posted item payload fixture
         def posted_item_payload_fixture
           {
             "item" => {

--- a/lib/wikidata_adaptor/version.rb
+++ b/lib/wikidata_adaptor/version.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 module WikidataAdaptor
+  # Gem version
   VERSION = "0.0.0"
 end


### PR DESCRIPTION
## Summary

This PR adds comprehensive YARD documentation to the WikidataAdaptor gem, bringing documentation coverage from 67% to 100%, and sets up automated documentation generation and publishing to GitHub Pages.

## Changes

### 1. YARD Tooling Setup
- Added `yard` gem (~> 0.9) for HTML documentation generation
- Added `redcarpet` gem (~> 3.6) for Markdown rendering
- Added `rubocop-yard` gem for YARD linting and enforcement
- Configured rubocop-yard plugin with 6 active cops
- Fixed existing YARD syntax errors (`Array[String]` → `Array<String>`)

### 2. Documentation Coverage: 67% → 100%
**Documented 58 previously undocumented items:**
- Main library (3): `WikidataAdaptor.rest_endpoint`, `Error` class, `VERSION` constant
- TestHelpers base (4): modules, constants, and base stub method
- TestHelpers modules (51): All error/fixture stub methods across 9 resource modules

**Final coverage:**
- 193/193 methods documented (100%)
- 26/26 modules documented (100%)
- 2/2 classes documented (100%)
- 2/2 constants documented (100%)

### 3. Development Tools
- **Rake task**: `bundle exec rake yard` generates documentation
- **Configuration file**: `.yardopts` centralizes YARD settings
  - Markdown markup with redcarpet
  - Includes README.md and CLAUDE.md in generated docs
  - Excludes private methods, includes protected methods

### 4. CI/CD Automation
- **GitHub Actions workflow** (`.github/workflows/docs.yml`)
  - Triggers on push to `main` or manual dispatch
  - Generates YARD documentation automatically
  - Deploys to GitHub Pages
  - Includes concurrency controls

### 5. Documentation Updates
- Updated `TODO.md` to mark YARD work complete
- Updated `CLAUDE.md` with Git/commit standards (from system changes)

## Testing

All existing tests pass:
- ✅ 125 RSpec examples, 0 failures
- ✅ RuboCop clean (53 files, 0 offenses)
- ✅ YARD stats: 100% documented

## Post-Merge Instructions

### Enable GitHub Pages (one-time setup)

After merging this PR, enable GitHub Pages to make the documentation publicly available:

1. Go to **Settings** → **Pages**
2. Under **Source**, select **GitHub Actions**
3. Save changes

Once enabled, documentation will be automatically published to:
**https://huwd.github.io/wikidata_adaptor/**

The GitHub Actions workflow will run on the next push to `main` and deploy the docs.

## Commits

1. `074b843` - build: Add YARD documentation tooling and fix syntax
2. `99b8069` - docs: Complete YARD documentation coverage to 100%
3. `6feba4d` - build: Add Rake task for generating YARD documentation
4. `c666587` - build: Add .yardopts configuration file
5. `34a321c` - ci: Add GitHub Actions workflow for YARD documentation
6. `df05ffa` - docs: Update TODO.md to mark YARD documentation complete

## Benefits

- **Better developer experience**: 100% documented API makes the gem easier to use
- **Automated updates**: Docs stay current with every merge to main
- **Public access**: GitHub Pages hosting makes docs accessible to all users
- **Quality enforcement**: rubocop-yard prevents documentation regressions
- **Consistent formatting**: `.yardopts` ensures uniform doc generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)