### PR TITLE
Configure Dependabot with aggressive grouping strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,46 @@
 version: 2
 updates:
+  # Bundler dependencies
+  # Weekly schedule provides 7-day cooldown between update checks
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "weekly" # 7-day cooldown
       day: "saturday"
       time: "06:00"
       timezone: "UTC"
-    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    open-pull-requests-limit: 3
+    groups:
+      # Group all minor and patch updates together
+      bundler-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions
+  # Weekly schedule provides 7-day cooldown between update checks
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "weekly" # 7-day cooldown
       day: "saturday"
       time: "06:30"
       timezone: "UTC"
-    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 2
+    groups:
+      # Group all minor and patch updates together
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Configures Dependabot for low-maintenance dependency management with aggressive grouping of minor and patch updates.

## Changes

### Grouping Strategy

**Bundler Dependencies** (all are dev dependencies):
- ✅ Group all minor and patch updates together
- ✅ Major updates remain separate for review
- Reduced PR limit: 10 → 3

**GitHub Actions**:
- ✅ Group all minor and patch updates together  
- ✅ Major updates remain separate for review
- Reduced PR limit: 5 → 2

### Schedule

- **Frequency**: Weekly (Saturday)
- **Bundler**: 06:00 UTC
- **Actions**: 06:30 UTC
- **Cooldown**: 7 days between update checks

## Configuration Details

```yaml
bundler-dependencies:
  patterns: ["*"]
  update-types: ["minor", "patch"]

github-actions:
  patterns: ["*"]
  update-types: ["minor", "patch"]
```

## Benefits

1. **Reduced PR volume** - Minor/patch updates grouped into 1-2 PRs per week
2. **Easier reviews** - Batched updates can be approved together
3. **Major update visibility** - Breaking changes get individual PRs
4. **Lower maintenance** - Weekly schedule with 7-day cooldown
5. **Predictable** - Updates arrive on Saturdays

## Example Behavior

**Before** (ungrouped):
- PR #1: Update rubocop 1.50.0 → 1.50.1
- PR #2: Update rspec 3.12.0 → 3.12.1
- PR #3: Update yard 0.9.34 → 0.9.35
- PR #4: Update webmock 3.18.0 → 3.18.1

**After** (grouped):
- PR #1: Update bundler-dependencies (4 gems: rubocop, rspec, yard, webmock)

**Major updates** (still separate):
- PR #2: Update rubocop 1.x → 2.0.0

## Testing

- ✅ YAML syntax valid
- ✅ All tests pass
- ✅ RuboCop clean

Dependabot will process this configuration on the next scheduled run (Saturday).

🤖 Generated with [Claude Code](https://claude.com/claude-code)