### PR TITLE
chore: Bump api_adaptor to v1.0.0

### DIFF
--- a/wikidata_adaptor.gemspec
+++ b/wikidata_adaptor.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "api_adaptor", ">= 0.1.0"
+  spec.add_dependency "api_adaptor", ">= 1.0.0"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
Released api_adaptor v1, should use that here.