### PR TITLE
fix(ci): Correct YAML syntax in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
           show-progress: false


### PR DESCRIPTION
## Summary

Fixes the release workflow that was failing with a YAML syntax error.

## Problem

The release workflow at [run #22039540939](https://github.com/huwd/wikidata_adaptor/actions/runs/22039540939) was failing with the error:

> There's not enough info to determine what you meant. Add one of these properties: run, shell, uses, with, working-directory

at line 27 of `.github/workflows/release.yml`.

## Root Cause

The `Checkout` step had malformed YAML syntax:
```yaml
- name: Checkout
- uses: actions/checkout@... # ← This `-` made it a separate list item
```

## Solution

Fixed the indentation by removing the `-` prefix from the `uses` directive, making it a property of the step:
```yaml
- name: Checkout
  uses: actions/checkout@... # ← Now properly indented as part of the step
```

## Testing

- [ ] Workflow file syntax is valid (GitHub Actions will validate on push)
- [ ] Can trigger manual dry-run to verify workflow executes

🤖 Generated with [Claude Code](https://claude.com/claude-code)