### PR TITLE
ci: Remove Ruby 3.2 from lint and test matrices

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.2", "3.3", "3.4", "4.0"]
+        ruby: ["3.3", "3.4", "4.0"]
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -36,7 +36,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.2", "3.3", "3.4", "4.0"]
+        ruby: ["3.3", "3.4", "4.0"]
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [Unreleased]
+
+### Changed
+
+- Removed Ruby 3.2 from CI lint and test matrices; Ruby 3.2 reached
+  end-of-life on 2026-04-01. Ruby 3.2 remains installable for this
+  release but runtime support will be dropped in the next major version.
+
 ## [1.0.0] - 2025-02-15
 
 ### Added


### PR DESCRIPTION
## Summary

- Removes Ruby 3.2 from the lint and test CI matrices in `quality-checks.yml`
- Ruby 3.2 reached end-of-life on 2026-04-01
- Ruby 3.2 remains installable via the gemspec `required_ruby_version >= 3.2.0` for this release; runtime support will be dropped in the next major version
- Mirrors the approach taken in [api_adaptor#82](https://github.com/huwd/api_adaptor/pull/82)

Closes #74

## Test plan

- [ ] CI runs against Ruby 3.3, 3.4, and 4.0 only
- [ ] No Ruby 3.2 jobs appear in the quality-checks workflow run