### PR TITLE
release(v1.0.1): Bump version to v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
-## [Unreleased]
+## [1.0.1] - 2026-06-13
 
 ### Changed
 
 - Removed Ruby 3.2 from CI lint and test matrices; Ruby 3.2 reached
   end-of-life on 2026-04-01. Ruby 3.2 remains installable for this
   release but runtime support will be dropped in the next major version.
+- Updated `api_adaptor` dependency to 1.0.3
+- Updated bundler development dependencies: `rubocop` (1.87.0),
+  `rubocop-rspec` (3.10.1), `rubocop-yard` (1.2.0)
+- Updated GitHub Actions: `actions/checkout` (v6.0.3),
+  `actions/upload-pages-artifact` (v5.0.0),
+  `github/codeql-action` (v4.36.2), `ruby/setup-ruby` (v1.310.0),
+  `rubygems/release-gem` (v1.3.0)
 
 ## [1.0.0] - 2025-02-15
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    wikidata_adaptor (1.0.0)
+    wikidata_adaptor (1.0.1)
       api_adaptor (>= 1.0.0)
 
 GEM

--- a/lib/wikidata_adaptor/version.rb
+++ b/lib/wikidata_adaptor/version.rb
@@ -2,5 +2,5 @@
 
 module WikidataAdaptor
   # Gem version
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
## Summary

Maintenance release — no API changes.

- Removed Ruby 3.2 from CI matrices (EOL 2026-04-01, closes #74)
- Updated `api_adaptor` to 1.0.3
- Updated bundler dev dependencies: `rubocop` 1.87.0, `rubocop-rspec` 3.10.1, `rubocop-yard` 1.2.0
- Updated GitHub Actions: `actions/checkout` v6.0.3, `actions/upload-pages-artifact` v5, `github/codeql-action` v4.36.2, `ruby/setup-ruby` v1.310.0, `rubygems/release-gem` v1.3.0

## Preflight results

- ✅ 125 RSpec examples, 0 failures
- ✅ RuboCop: 53 files, no offenses
- ✅ YARD: 100% documented (193/193 methods)
- ✅ `gem build` → `wikidata_adaptor-1.0.1.gem`
- ✅ `gem install` + `require` → `WikidataAdaptor::VERSION` = `"1.0.1"`

## Test plan

- [ ] CI passes on this PR
- [ ] After merge: tag `v1.0.1` → release workflow publishes to RubyGems